### PR TITLE
Attributes, colliders (v3)

### DIFF
--- a/Editor/RegisterTag.cs
+++ b/Editor/RegisterTag.cs
@@ -3,14 +3,14 @@
 namespace Editor {
 
     [InitializeOnLoad]
-    public class RegisterTag {
+    public sealed class RegisterTag {
 
         static RegisterTag() => AddTag(ObjectExporter.ExporterIgnoredTag);
 
         private static void AddTag(string tagName) {
             var tagManager = new SerializedObject(AssetDatabase.LoadAllAssetsAtPath("ProjectSettings/TagManager.asset")[0]);
             var tagsProp = tagManager.FindProperty("tags");
-            if (PropertyExists(tagsProp, 0, tagsProp.arraySize, tagName)) 
+            if (PropertyExists(tagsProp, 0, tagsProp.arraySize, tagName))
                 return;
             var index = tagsProp.arraySize;
             tagsProp.InsertArrayElementAtIndex(index);

--- a/Editor/sloc/ColliderModeEditor.cs
+++ b/Editor/sloc/ColliderModeEditor.cs
@@ -14,7 +14,6 @@ namespace Editor.sloc {
 
         private static readonly List<string> Options = Enum.GetValues(typeof(PrimitiveObject.ColliderCreationMode))
             .Cast<PrimitiveObject.ColliderCreationMode>()
-            .Where(e => e != PrimitiveObject.ColliderCreationMode.Unset)
             .Select(ModeToString).ToList();
 
         private static readonly string[] OptionsArray = Options.ToArray();

--- a/Editor/sloc/ColliderModeEditor.cs
+++ b/Editor/sloc/ColliderModeEditor.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using slocExporter;
 using slocExporter.Objects;
 using UnityEditor;
+using UnityEngine;
 using static slocExporter.ColliderModeSetter;
 
 namespace Editor.sloc {
@@ -24,6 +25,7 @@ namespace Editor.sloc {
                 return;
             var current = ((ColliderModeSetter) targetsCache[0]).mode;
             var mode = StringToMode(OptionsArray[EditorGUILayout.Popup("Collider Creation Mode", Options.IndexOf(ModeToString(current)), OptionsArray)]);
+            GUILayout.Label(new GUIContent("What is this?", GetModeDescription(mode)), EditorStyles.boldLabel);
             foreach (var t in targetsCache)
                 ((ColliderModeSetter) t).mode = mode;
         }

--- a/Editor/sloc/ColliderModeEditor.cs
+++ b/Editor/sloc/ColliderModeEditor.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using slocExporter;
+using slocExporter.Objects;
+using UnityEditor;
+using static slocExporter.ColliderModeSetter;
+
+namespace Editor.sloc {
+
+    [CustomEditor(typeof(ColliderModeSetter))]
+    [CanEditMultipleObjects]
+    public sealed class ColliderModeEditor : UnityEditor.Editor {
+
+        private static readonly List<string> Options = Enum.GetValues(typeof(PrimitiveObject.ColliderCreationMode))
+            .Cast<PrimitiveObject.ColliderCreationMode>()
+            .Where(e => e != PrimitiveObject.ColliderCreationMode.Unset)
+            .Select(ModeToString).ToList();
+
+        private static readonly string[] OptionsArray = Options.ToArray();
+
+        public override void OnInspectorGUI() {
+            var targetsCache = targets;
+            if (targetsCache.Length < 1)
+                return;
+            var current = ((ColliderModeSetter) targetsCache[0]).mode;
+            var mode = StringToMode(OptionsArray[EditorGUILayout.Popup("Collider Creation Mode", Options.IndexOf(ModeToString(current)), OptionsArray)]);
+            foreach (var t in targetsCache)
+                ((ColliderModeSetter) t).mode = mode;
+        }
+
+    }
+
+}

--- a/Editor/sloc/ExporterWindow.cs
+++ b/Editor/sloc/ExporterWindow.cs
@@ -39,7 +39,7 @@ namespace Editor.sloc {
             _filePath = EditorGUILayout.TextField("Path", _filePath);
             if (GUILayout.Button("Select File")) {
                 var sceneName = SceneManager.GetActiveScene().name;
-                var path = EditorUtility.SaveFilePanel("Save sloc file", Path.GetDirectoryName(_filePath.ToFullAppDataPath()), string.IsNullOrEmpty(sceneName) ? "MyObject" : sceneName, "sloc");
+                var path = EditorUtility.SaveFilePanel("Save sloc file", string.IsNullOrEmpty(_filePath) ? null : Path.GetDirectoryName(_filePath.ToFullAppDataPath()), string.IsNullOrEmpty(sceneName) ? "MyObject" : sceneName, "sloc");
                 if (!string.IsNullOrEmpty(path))
                     _filePath = path.ToShortAppDataPath();
             }

--- a/Editor/sloc/ExporterWindow.cs
+++ b/Editor/sloc/ExporterWindow.cs
@@ -31,7 +31,7 @@ namespace Editor.sloc {
             }
 
             GUILayout.Label("Attributes", EditorStyles.boldLabel);
-            _lossyColor = EditorGUILayout.Toggle(new GUIContent("Lossy Colors", "Uses a single 8-bit integer for colors instead of 4 8-bit floats. This reduces file size but limits the RGB color range to 0-255 and therefore loses precision."), _lossyColor);
+            _lossyColor = EditorGUILayout.Toggle(new GUIContent("Lossy Colors", "Uses a single 32-bit integer for colors instead of four 32-bit floats (16 bytes). This reduces file size but limits the RGB color range to 0-255 and therefore loses precision."), _lossyColor);
             GUILayout.Label("Export", EditorStyles.boldLabel);
             _debug = EditorGUILayout.Toggle("Show Debug", _debug);
             if (GUILayout.Button("Export All"))

--- a/Editor/sloc/ExporterWindow.cs
+++ b/Editor/sloc/ExporterWindow.cs
@@ -69,7 +69,7 @@ namespace Editor.sloc {
             if (_lossyColor)
                 attribute |= slocAttributes.LossyColors;
             if (_collider != PrimitiveObject.ColliderCreationMode.Unset)
-                attribute |= slocAttributes.ForcedColliderMode;
+                attribute |= slocAttributes.DefaultColliderMode;
             return attribute;
         }
 

--- a/Editor/sloc/ExporterWindow.cs
+++ b/Editor/sloc/ExporterWindow.cs
@@ -36,7 +36,7 @@ namespace Editor.sloc {
         }
 
         private static void Export(bool selectedOnly) {
-            if (!ObjectExporter.Init(_debug, _filePath)) {
+            if (!ObjectExporter.Init(_debug, _filePath, slocAttributes.None)) {
                 EditorUtility.DisplayDialog(ProgressbarTitle, "Export is already in progress", "OK");
                 return;
             }

--- a/Editor/sloc/ExporterWindow.cs
+++ b/Editor/sloc/ExporterWindow.cs
@@ -14,6 +14,8 @@ namespace Editor.sloc {
     public sealed class ExporterWindow : EditorWindow {
 
         private const string ProgressbarTitle = "slocExporter";
+        private const string LossyColorDescription = "Uses a single 32-bit integer for colors instead of four 32-bit floats (16 bytes per color). This reduces file size but limits the RGB color range to 0-255 and therefore loses precision.";
+        private const string Asterisk = "Hover over an item with an * for more information.";
 
         [MenuItem("Window/sloc/Export")]
         public static void ShowWindow() => GetWindow(typeof(ExporterWindow), true, "Export to sloc");
@@ -42,15 +44,19 @@ namespace Editor.sloc {
                     _filePath = path.ToShortAppDataPath();
             }
 
+            GUILayout.Space(10);
             GUILayout.Label("Attributes", EditorStyles.boldLabel);
-            _lossyColor = EditorGUILayout.Toggle(new GUIContent("Lossy Colors", "Uses a single 32-bit integer for colors instead of four 32-bit floats (16 bytes). This reduces file size but limits the RGB color range to 0-255 and therefore loses precision."), _lossyColor);
-            _collider = StringToMode(OptionsArray[EditorGUILayout.Popup("Forced Collider Mode", Options.IndexOf(ModeToString(_collider)), OptionsArray)]);
+            _lossyColor = EditorGUILayout.Toggle(new GUIContent("Lossy Colors*", LossyColorDescription), _lossyColor);
+            _collider = StringToMode(OptionsArray[EditorGUILayout.Popup(new GUIContent("Default Collider Mode*", "The default collider creation mode to use for primitive objects.\n" + GetModeDescription(_collider, true)), Options.IndexOf(ModeToString(_collider)), OptionsArray)]);
+            GUILayout.Space(10);
             GUILayout.Label("Export", EditorStyles.boldLabel);
             _debug = EditorGUILayout.Toggle("Show Debug", _debug);
             if (GUILayout.Button("Export All"))
                 Export(false);
             if (GUILayout.Button("Export Selected"))
                 Export(true);
+            GUILayout.Space(20);
+            GUILayout.Label(Asterisk, EditorStyles.centeredGreyMiniLabel);
         }
 
         private static void Export(bool selectedOnly) {

--- a/Editor/sloc/ImporterWindow.cs
+++ b/Editor/sloc/ImporterWindow.cs
@@ -4,7 +4,7 @@ using UnityEngine;
 
 namespace Editor.sloc {
 
-    public class ImporterWindow : EditorWindow {
+    public sealed class ImporterWindow : EditorWindow {
 
         private const string ProgressbarTitle = "slocImporter";
 

--- a/Editor/sloc/ImporterWindow.cs
+++ b/Editor/sloc/ImporterWindow.cs
@@ -13,13 +13,19 @@ namespace Editor.sloc {
 
         private static string _filePath = "";
 
+        private static bool _useExistingMaterials = true;
+
+        private static bool _colorsFolderOnly;
+
         private void OnGUI() {
+            _useExistingMaterials = EditorGUILayout.Toggle(new GUIContent("Use Existing Materials", "When enabled, the importer tries to use existing materials in the assets."), _useExistingMaterials);
+            _colorsFolderOnly = EditorGUILayout.Toggle(new GUIContent("Search in Colors", "When enabled, only materials in the Assets/Colors folder will be attempted to be used."), _colorsFolderOnly);
             _filePath = EditorGUILayout.TextField("File Path:", _filePath);
             if (GUILayout.Button("Select File"))
                 _filePath = EditorUtility.OpenFilePanel("Select sloc file to import", _filePath, "sloc").ToShortAppDataPath();
             if (!GUILayout.Button("Import Objects"))
                 return;
-            if (!slocImporter.Init(_filePath)) {
+            if (!slocImporter.Init(_filePath, _useExistingMaterials, _colorsFolderOnly)) {
                 EditorUtility.DisplayDialog(ProgressbarTitle, "Import is already in progress", "OK");
                 return;
             }

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Allows for exporting primitive objects in Unity scenes to use in SCP: Secret Laboratory.
 
-Use the [slocLoader](https://github.com/Axwabo/slocLoader/) plugin to load them in game.
+Use the [slocLoader](https://github.com/Axwabo/slocLoader/) plugin to load them in the game.
 
 ![Logo](https://github.com/Axwabo/slocLoader/blob/main/logo%20small.png?raw=true)
 

--- a/Scripts/ObjectExporter.cs
+++ b/Scripts/ObjectExporter.cs
@@ -11,6 +11,7 @@ using slocExporter.Readers;
 using UnityEditor;
 using UnityEngine;
 
+// ReSharper disable SuggestBaseTypeForParameter
 public static class ObjectExporter {
 
     public const string ExporterIgnoredTag = "slocExporter Ignored";
@@ -79,6 +80,7 @@ public static class ObjectExporter {
         var allObjects = GetObjects(selectedOnly);
         var objectsById = new Dictionary<int, slocGameObject>();
         var renderers = new Dictionary<int, MeshRenderer>();
+        var colliders = new Dictionary<int, PrimitiveObject.ColliderCreationMode>();
         var allObjectsCount = allObjects.Length;
         var floatObjectsCount = (float) allObjectsCount;
         Log($"Found {allObjectsCount} objects in total.");
@@ -86,7 +88,7 @@ public static class ObjectExporter {
             var o = allObjects[i];
             var progressString = $"Processing objects ({i + 1} of {allObjectsCount})";
             var progressValue = i / floatObjectsCount;
-            if (TaggedAsIgnored(o)) {
+            if (IsTaggedAsIgnored(o)) {
                 Log($"Skipped object {o.name} because it's tagged as {ExporterIgnoredTag}");
                 updateProgress?.Invoke(progressString, progressValue);
                 continue;
@@ -94,6 +96,7 @@ public static class ObjectExporter {
 
             foreach (var component in o.GetComponents<Component>()) {
                 var skip = component switch {
+                    ColliderModeSetter setter => SetMode(o, setter, colliders),
                     ExporterIgnored => IgnoreObject(o, objectsById),
                     MeshFilter meshFilter => ProcessMeshFilter(o, meshFilter, objectsById),
                     MeshRenderer meshRenderer => ProcessRenderer(o, meshRenderer, renderers),
@@ -113,6 +116,8 @@ public static class ObjectExporter {
         Log("Processing material colors...");
         RenderersToMaterials(renderers, objectsById, updateProgress);
         var nonEmpty = objectsById.Where(e => e.Value is {IsValid: true}).ToList();
+        Log("Setting collider modes...");
+        SetColliderModes(nonEmpty, colliders, updateProgress);
         Log("Writing file...");
         WriteObjects(file, nonEmpty, attributes, collider, updateProgress);
         LogWarning($"[slocExporter] Export done in {stopwatch.ElapsedMilliseconds}ms; {nonEmpty.Count} objects exported to {file.ToShortAppDataPath()}");
@@ -145,58 +150,25 @@ public static class ObjectExporter {
         return list.ToArray();
     }
 
-    private static bool TaggedAsIgnored(GameObject gameObject) {
+    private static bool IsTaggedAsIgnored(GameObject gameObject) {
         var root = gameObject.transform.root.gameObject;
         return gameObject.CompareTag(ExporterIgnoredTag) || gameObject.TryGetComponent(out ExporterIgnored _) || root.CompareTag(RoomTag) || root.CompareTag(ExporterIgnoredTag) || root.TryGetComponent(out ExporterIgnored _);
+    }
+
+    private static bool SetMode(GameObject gameObject, ColliderModeSetter setter, Dictionary<int, PrimitiveObject.ColliderCreationMode> colliderCreationModes) {
+        var mode = setter.mode;
+        if (mode is PrimitiveObject.ColliderCreationMode.Unset)
+            return false;
+        var id = gameObject.GetInstanceID();
+        Log("Setting collider mode for " + id + " to " + mode);
+        colliderCreationModes[id] = mode;
+        return false;
     }
 
     private static bool IgnoreObject(GameObject gameObject, Dictionary<int, slocGameObject> objectsById) {
         Log($"{gameObject.name} is flagged as ExporterIgnored");
         objectsById.Remove(gameObject.GetInstanceID());
         return true;
-    }
-
-    public static void RenderersToMaterials(Dictionary<int, MeshRenderer> renderers, Dictionary<int, slocGameObject> objectList, Action<string, float> updateProgress = null) {
-        updateProgress?.Invoke("Setting materials", 0);
-        var list = renderers.ToList();
-        var count = list.Count;
-        var floatCount = (float) count;
-        for (var i = 0; i < count; i++) {
-            updateProgress?.Invoke($"Setting materials ({i + 1} of {count})", i / floatCount);
-            var (id, r) = list[i];
-            var mat = r.sharedMaterial;
-            if (mat == null || !objectList.TryGetValue(id, out var obj) || obj is not PrimitiveObject p)
-                continue;
-            p.MaterialColor = mat.color;
-            Log($"Set material color for {id} to {mat.color}");
-        }
-    }
-
-    private static void WriteObjects(string file, List<KeyValuePair<int, slocGameObject>> nonEmpty, slocAttributes attributes, PrimitiveObject.ColliderCreationMode colliderMode, Action<string, float> updateProgress = null) {
-        updateProgress?.Invoke("Writing objects", 0);
-        var writer = new BinaryWriter(File.Open(file, FileMode.Create), Encoding.UTF8);
-        writer.Write(API.slocVersion);
-        var count = nonEmpty.Count;
-        var header = new slocHeader(count, attributes, colliderMode);
-        header.WriteTo(writer);
-        var floatCount = (float) count;
-        for (var i = 0; i < count; i++) {
-            var obj = nonEmpty[i];
-            obj.Value.WriteTo(writer, header);
-            updateProgress?.Invoke($"Writing objects ({i + 1} of {count})", i / floatCount);
-        }
-
-        writer.Close();
-    }
-
-    public static void Log(object o) {
-        if (_debug)
-            UnityEngine.Debug.Log(o);
-    }
-
-    public static void LogWarning(object o) {
-        if (_debug)
-            UnityEngine.Debug.LogWarning(o);
     }
 
     public static bool ProcessLight(GameObject o, Light l, Dictionary<int, slocGameObject> objectList) {
@@ -245,6 +217,62 @@ public static class ObjectExporter {
             Transform = oTransform
         };
         return false;
+    }
+
+    public static void RenderersToMaterials(Dictionary<int, MeshRenderer> renderers, Dictionary<int, slocGameObject> objectList, Action<string, float> updateProgress = null) {
+        updateProgress?.Invoke("Setting materials", 0);
+        var list = renderers.ToList();
+        var count = list.Count;
+        var floatCount = (float) count;
+        for (var i = 0; i < count; i++) {
+            updateProgress?.Invoke($"Setting materials ({i + 1} of {count})", i / floatCount);
+            var (id, r) = list[i];
+            var mat = r.sharedMaterial;
+            if (mat == null || !objectList.TryGetValue(id, out var obj) || obj is not PrimitiveObject p)
+                continue;
+            p.MaterialColor = mat.color;
+            Log($"Set material color for {id} to {mat.color}");
+        }
+    }
+
+    private static void SetColliderModes(List<KeyValuePair<int, slocGameObject>> objects, Dictionary<int, PrimitiveObject.ColliderCreationMode> modes, Action<string, float> updateProgress) {
+        var count = objects.Count;
+        var floatCount = (float) count;
+        for (var i = 0; i < count; i++) {
+            updateProgress?.Invoke($"Setting collider modes ({i + 1} of {count})", i / floatCount);
+            var (id, obj) = objects[i];
+            if (obj is not PrimitiveObject p)
+                continue;
+            if (modes.TryGetValue(id, out var mode))
+                p.ColliderMode = mode;
+        }
+    }
+
+    private static void WriteObjects(string file, List<KeyValuePair<int, slocGameObject>> nonEmpty, slocAttributes attributes, PrimitiveObject.ColliderCreationMode colliderMode, Action<string, float> updateProgress = null) {
+        updateProgress?.Invoke("Writing objects", 0);
+        var writer = new BinaryWriter(File.Open(file, FileMode.Create), Encoding.UTF8);
+        writer.Write(API.slocVersion);
+        var count = nonEmpty.Count;
+        var header = new slocHeader(count, attributes, colliderMode);
+        header.WriteTo(writer);
+        var floatCount = (float) count;
+        for (var i = 0; i < count; i++) {
+            var obj = nonEmpty[i];
+            obj.Value.WriteTo(writer, header);
+            updateProgress?.Invoke($"Writing objects ({i + 1} of {count})", i / floatCount);
+        }
+
+        writer.Close();
+    }
+
+    public static void Log(object o) {
+        if (_debug)
+            UnityEngine.Debug.Log(o);
+    }
+
+    public static void LogWarning(object o) {
+        if (_debug)
+            UnityEngine.Debug.LogWarning(o);
     }
 
     public static void CheckIfEmpty(GameObject o, Dictionary<int, slocGameObject> objectList) {

--- a/Scripts/ObjectExporter.cs
+++ b/Scripts/ObjectExporter.cs
@@ -177,8 +177,8 @@ public static class ObjectExporter {
         var writer = new BinaryWriter(File.Open(file, FileMode.Create), Encoding.UTF8);
         writer.Write(API.slocVersion);
         var count = nonEmpty.Count;
-        writer.Write(count);
         var header = new slocHeader(count, attributes, colliderMode);
+        header.WriteTo(writer);
         var floatCount = (float) count;
         for (var i = 0; i < count; i++) {
             var obj = nonEmpty[i];

--- a/Scripts/ObjectExporter.cs
+++ b/Scripts/ObjectExporter.cs
@@ -173,6 +173,7 @@ public static class ObjectExporter {
         writer.Write(API.slocVersion);
         var count = nonEmpty.Count;
         writer.Write(count);
+        writer.Write((byte) attributes);
         var floatCount = (float) count;
         for (var i = 0; i < count; i++) {
             var obj = nonEmpty[i];

--- a/Scripts/slocExporter/API.cs
+++ b/Scripts/slocExporter/API.cs
@@ -40,9 +40,10 @@ namespace slocExporter {
         private static ushort ReadVersionSafe(BufferedStream buffered, BinaryReader binaryReader) {
             var newVersion = binaryReader.ReadUInt16();
             var oldVersion = binaryReader.ReadUInt16();
-            if (oldVersion is not 0)
+            if (oldVersion is 0)
                 return (ushort) (newVersion | (uint) oldVersion << 16);
-            ReadPosField.SetValue(buffered, (int) ReadPosField.GetValue(buffered) - sizeof(ushort)); // rewind the buffer by two bytes, so the whole stream won't be malformed data
+            var newPos = (int) ReadPosField.GetValue(buffered) - sizeof(ushort);
+            ReadPosField.SetValue(buffered, newPos); // rewind the buffer by two bytes, so the whole stream won't be malformed data
             return newVersion;
         }
 

--- a/Scripts/slocExporter/API.cs
+++ b/Scripts/slocExporter/API.cs
@@ -15,7 +15,7 @@ namespace slocExporter {
 
         public static readonly IObjectReader DefaultReader = new Ver2Reader();
 
-        private static readonly Dictionary<uint, IObjectReader> VersionReaders = new Dictionary<uint, IObjectReader> {
+        private static readonly Dictionary<uint, IObjectReader> VersionReaders = new() {
             {1, new Ver1Reader()},
             {2, new Ver2Reader()}
         };
@@ -167,19 +167,19 @@ namespace slocExporter {
             AssetDatabase.CreateAsset(material, "Assets/Colors/" + $"Material-{color.ToString()}" + ".mat");
         }
 
-        public static slocGameObject ReadObject(this BinaryReader stream, uint version = 0, IObjectReader objectReader = null) => (objectReader ?? GetReader(version)).Read(stream);
+        public static slocGameObject ReadObject(this BinaryReader stream, uint version = 0, IObjectReader objectReader = null, slocAttributes attributes = slocAttributes.None) => (objectReader ?? GetReader(version)).Read(stream, attributes);
 
-        public static slocTransform ReadTransform(this BinaryReader reader) => new slocTransform {
+        public static slocTransform ReadTransform(this BinaryReader reader) => new() {
             Position = reader.ReadVector(),
             Scale = reader.ReadVector(),
             Rotation = reader.ReadQuaternion()
         };
 
-        public static Vector3 ReadVector(this BinaryReader reader) => new Vector3(reader.ReadSingle(), reader.ReadSingle(), reader.ReadSingle());
+        public static Vector3 ReadVector(this BinaryReader reader) => new(reader.ReadSingle(), reader.ReadSingle(), reader.ReadSingle());
 
-        public static Quaternion ReadQuaternion(this BinaryReader reader) => new Quaternion(reader.ReadSingle(), reader.ReadSingle(), reader.ReadSingle(), reader.ReadSingle());
+        public static Quaternion ReadQuaternion(this BinaryReader reader) => new(reader.ReadSingle(), reader.ReadSingle(), reader.ReadSingle(), reader.ReadSingle());
 
-        public static Color ReadColor(this BinaryReader reader) => new Color(reader.ReadSingle(), reader.ReadSingle(), reader.ReadSingle(), reader.ReadSingle());
+        public static Color ReadColor(this BinaryReader reader) => new(reader.ReadSingle(), reader.ReadSingle(), reader.ReadSingle(), reader.ReadSingle());
 
         public static PrimitiveType ToPrimitiveType(this ObjectType type) => type switch {
             ObjectType.Cube => PrimitiveType.Cube,

--- a/Scripts/slocExporter/ColliderModeSetter.cs
+++ b/Scripts/slocExporter/ColliderModeSetter.cs
@@ -7,20 +7,22 @@ namespace slocExporter {
     public sealed class ColliderModeSetter : MonoBehaviour {
 
         private const string NoCollider = "No Collider";
-        private const string ClientOnly = "Client Only";
-        private const string ServerOnlySpawnedObject = "Server-Only Spawned Object";
+        private const string ClientOnly = "Client-Only";
+        private const string ServerOnly = "Server-Only Spawned Object";
         private const string Both = "Both";
         private const string Trigger = "Trigger";
-        private const string ServerOnlyTrigger = "Server-Only Trigger";
+        private const string NonSpawnedTrigger = "Non-Spawned Trigger";
         private const string ServerOnlyNonSpawnedObject = "Server-Only Non-Spawned Object";
+        private const string NoColliderNonSpawnedObject = "Colliderless Non-Spawned Object";
 
         private const string DescriptionNoCollider = "The object will neither have a collider on the client nor on the server.";
         private const string DescriptionClientOnly = "The object will have a collider on the client but not on the server.";
-        private const string DescriptionServerOnlySpawnedObject = "The object will be spawned on the client.\nIt will only have a collider on the server.";
+        private const string DescriptionServerOnly = "The object will be spawned on the client.\nIt will only have a collider on the server.";
         private const string DescriptionBoth = "The object will have a collider on the client and on the server.";
         private const string DescriptionTrigger = "The object will have a trigger collider on the server but won't be have a collider on the client.";
-        private const string DescriptionServerOnlyTrigger = "The object will NOT be spawned on the client.\nIt will have a trigger collider on the server.";
+        private const string DescriptionNonSpawnedTrigger = "The object will NOT be spawned on the client.\nIt will have a trigger collider on the server.";
         private const string DescriptionServerOnlyNonSpawnedObject = "The object will NOT be spawned on the client.\nIt will only have a collider on the server.";
+        private const string DescriptionNoColliderNonSpawnedObject = "The object will NOT be spawned on the client.\nIt will neither have a collider on the client nor on the server.";
         private const string DescriptionUnset = "The default collider mode will be used if set in the headers; otherwise, it will use the BOTH mode.";
         private const string DescriptionHeaderUnset = "This mode will be used for all primitives that don't have a collider mode set.";
 
@@ -29,33 +31,36 @@ namespace slocExporter {
         public static string ModeToString(PrimitiveObject.ColliderCreationMode mode) => mode switch {
             PrimitiveObject.ColliderCreationMode.NoCollider => NoCollider,
             PrimitiveObject.ColliderCreationMode.ClientOnly => ClientOnly,
-            PrimitiveObject.ColliderCreationMode.ServerOnlySpawned => ServerOnlySpawnedObject,
+            PrimitiveObject.ColliderCreationMode.ServerOnly => ServerOnly,
             PrimitiveObject.ColliderCreationMode.Both => Both,
             PrimitiveObject.ColliderCreationMode.Trigger => Trigger,
-            PrimitiveObject.ColliderCreationMode.ServerOnlyTrigger => ServerOnlyTrigger,
+            PrimitiveObject.ColliderCreationMode.NonSpawnedTrigger => NonSpawnedTrigger,
             PrimitiveObject.ColliderCreationMode.ServerOnlyNonSpawned => ServerOnlyNonSpawnedObject,
+            PrimitiveObject.ColliderCreationMode.NoColliderNonSpawned => NoColliderNonSpawnedObject,
             _ => "Unset"
         };
 
         public static PrimitiveObject.ColliderCreationMode StringToMode(string mode) => mode switch {
             NoCollider => PrimitiveObject.ColliderCreationMode.NoCollider,
             ClientOnly => PrimitiveObject.ColliderCreationMode.ClientOnly,
-            ServerOnlySpawnedObject => PrimitiveObject.ColliderCreationMode.ServerOnlySpawned,
+            ServerOnly => PrimitiveObject.ColliderCreationMode.ServerOnly,
             Both => PrimitiveObject.ColliderCreationMode.Both,
             Trigger => PrimitiveObject.ColliderCreationMode.Trigger,
-            ServerOnlyTrigger => PrimitiveObject.ColliderCreationMode.ServerOnlyTrigger,
+            NonSpawnedTrigger => PrimitiveObject.ColliderCreationMode.NonSpawnedTrigger,
             ServerOnlyNonSpawnedObject => PrimitiveObject.ColliderCreationMode.ServerOnlyNonSpawned,
+            NoColliderNonSpawnedObject => PrimitiveObject.ColliderCreationMode.NoColliderNonSpawned,
             _ => PrimitiveObject.ColliderCreationMode.Unset
         };
 
         public static string GetModeDescription(PrimitiveObject.ColliderCreationMode mode, bool isHeader = false) => mode switch {
             PrimitiveObject.ColliderCreationMode.NoCollider => DescriptionNoCollider,
             PrimitiveObject.ColliderCreationMode.ClientOnly => DescriptionClientOnly,
-            PrimitiveObject.ColliderCreationMode.ServerOnlySpawned => DescriptionServerOnlySpawnedObject,
+            PrimitiveObject.ColliderCreationMode.ServerOnly => DescriptionServerOnly,
             PrimitiveObject.ColliderCreationMode.Both => DescriptionBoth,
             PrimitiveObject.ColliderCreationMode.Trigger => DescriptionTrigger,
-            PrimitiveObject.ColliderCreationMode.ServerOnlyTrigger => DescriptionServerOnlyTrigger,
+            PrimitiveObject.ColliderCreationMode.NonSpawnedTrigger => DescriptionNonSpawnedTrigger,
             PrimitiveObject.ColliderCreationMode.ServerOnlyNonSpawned => DescriptionServerOnlyNonSpawnedObject,
+            PrimitiveObject.ColliderCreationMode.NoColliderNonSpawned => DescriptionNoColliderNonSpawnedObject,
             _ => isHeader ? DescriptionHeaderUnset : DescriptionUnset
         };
 

--- a/Scripts/slocExporter/ColliderModeSetter.cs
+++ b/Scripts/slocExporter/ColliderModeSetter.cs
@@ -1,0 +1,33 @@
+﻿using slocExporter.Objects;
+using UnityEngine;
+
+namespace slocExporter {
+
+    [DisallowMultipleComponent]
+    public sealed class ColliderModeSetter : MonoBehaviour {
+
+        public PrimitiveObject.ColliderCreationMode mode = PrimitiveObject.ColliderCreationMode.Both;
+
+        public static string ModeToString(PrimitiveObject.ColliderCreationMode mode) => mode switch {
+            PrimitiveObject.ColliderCreationMode.NoCollider => "No Collider",
+            PrimitiveObject.ColliderCreationMode.ClientOnly => "Client Only",
+            PrimitiveObject.ColliderCreationMode.ServerOnly => "Server Only",
+            PrimitiveObject.ColliderCreationMode.Both => "Both",
+            PrimitiveObject.ColliderCreationMode.Trigger => "Trigger",
+            PrimitiveObject.ColliderCreationMode.ServerOnlyTrigger => "Server-Only Trigger",
+            _ => "Unset"
+        };
+
+        public static PrimitiveObject.ColliderCreationMode StringToMode(string mode) => mode switch {
+            "No Collider" => PrimitiveObject.ColliderCreationMode.NoCollider,
+            "Client Only" => PrimitiveObject.ColliderCreationMode.ClientOnly,
+            "Server Only" => PrimitiveObject.ColliderCreationMode.ServerOnly,
+            "Both" => PrimitiveObject.ColliderCreationMode.Both,
+            "Trigger" => PrimitiveObject.ColliderCreationMode.Trigger,
+            "Server-Only Trigger" => PrimitiveObject.ColliderCreationMode.ServerOnlyTrigger,
+            _ => PrimitiveObject.ColliderCreationMode.Unset
+        };
+
+    }
+
+}

--- a/Scripts/slocExporter/ColliderModeSetter.cs
+++ b/Scripts/slocExporter/ColliderModeSetter.cs
@@ -6,7 +6,7 @@ namespace slocExporter {
     [DisallowMultipleComponent]
     public sealed class ColliderModeSetter : MonoBehaviour {
 
-        public PrimitiveObject.ColliderCreationMode mode = PrimitiveObject.ColliderCreationMode.Both;
+        public PrimitiveObject.ColliderCreationMode mode = PrimitiveObject.ColliderCreationMode.Unset;
 
         public static string ModeToString(PrimitiveObject.ColliderCreationMode mode) => mode switch {
             PrimitiveObject.ColliderCreationMode.NoCollider => "No Collider",

--- a/Scripts/slocExporter/ColliderModeSetter.cs
+++ b/Scripts/slocExporter/ColliderModeSetter.cs
@@ -6,26 +6,57 @@ namespace slocExporter {
     [DisallowMultipleComponent]
     public sealed class ColliderModeSetter : MonoBehaviour {
 
+        private const string NoCollider = "No Collider";
+        private const string ClientOnly = "Client Only";
+        private const string ServerOnlySpawnedObject = "Server-Only Spawned Object";
+        private const string Both = "Both";
+        private const string Trigger = "Trigger";
+        private const string ServerOnlyTrigger = "Server-Only Trigger";
+        private const string ServerOnlyNonSpawnedObject = "Server-Only Non-Spawned Object";
+
+        private const string DescriptionNoCollider = "The object will neither have a collider on the client nor on the server.";
+        private const string DescriptionClientOnly = "The object will have a collider on the client but not on the server.";
+        private const string DescriptionServerOnlySpawnedObject = "The object will be spawned on the client.\nIt will only have a collider on the server.";
+        private const string DescriptionBoth = "The object will have a collider on the client and on the server.";
+        private const string DescriptionTrigger = "The object will have a trigger collider on the server but won't be have a collider on the client.";
+        private const string DescriptionServerOnlyTrigger = "The object will NOT be spawned on the client.\nIt will have a trigger collider on the server.";
+        private const string DescriptionServerOnlyNonSpawnedObject = "The object will NOT be spawned on the client.\nIt will only have a collider on the server.";
+        private const string DescriptionUnset = "The default collider mode will be used if set in the headers; otherwise, it will use the BOTH mode.";
+        private const string DescriptionHeaderUnset = "This mode will be used for all primitives that don't have a collider mode set.";
+
         public PrimitiveObject.ColliderCreationMode mode = PrimitiveObject.ColliderCreationMode.Unset;
 
         public static string ModeToString(PrimitiveObject.ColliderCreationMode mode) => mode switch {
-            PrimitiveObject.ColliderCreationMode.NoCollider => "No Collider",
-            PrimitiveObject.ColliderCreationMode.ClientOnly => "Client Only",
-            PrimitiveObject.ColliderCreationMode.ServerOnly => "Server Only",
-            PrimitiveObject.ColliderCreationMode.Both => "Both",
-            PrimitiveObject.ColliderCreationMode.Trigger => "Trigger",
-            PrimitiveObject.ColliderCreationMode.ServerOnlyTrigger => "Server-Only Trigger",
+            PrimitiveObject.ColliderCreationMode.NoCollider => NoCollider,
+            PrimitiveObject.ColliderCreationMode.ClientOnly => ClientOnly,
+            PrimitiveObject.ColliderCreationMode.ServerOnlySpawned => ServerOnlySpawnedObject,
+            PrimitiveObject.ColliderCreationMode.Both => Both,
+            PrimitiveObject.ColliderCreationMode.Trigger => Trigger,
+            PrimitiveObject.ColliderCreationMode.ServerOnlyTrigger => ServerOnlyTrigger,
+            PrimitiveObject.ColliderCreationMode.ServerOnlyNonSpawned => ServerOnlyNonSpawnedObject,
             _ => "Unset"
         };
 
         public static PrimitiveObject.ColliderCreationMode StringToMode(string mode) => mode switch {
-            "No Collider" => PrimitiveObject.ColliderCreationMode.NoCollider,
-            "Client Only" => PrimitiveObject.ColliderCreationMode.ClientOnly,
-            "Server Only" => PrimitiveObject.ColliderCreationMode.ServerOnly,
-            "Both" => PrimitiveObject.ColliderCreationMode.Both,
-            "Trigger" => PrimitiveObject.ColliderCreationMode.Trigger,
-            "Server-Only Trigger" => PrimitiveObject.ColliderCreationMode.ServerOnlyTrigger,
+            NoCollider => PrimitiveObject.ColliderCreationMode.NoCollider,
+            ClientOnly => PrimitiveObject.ColliderCreationMode.ClientOnly,
+            ServerOnlySpawnedObject => PrimitiveObject.ColliderCreationMode.ServerOnlySpawned,
+            Both => PrimitiveObject.ColliderCreationMode.Both,
+            Trigger => PrimitiveObject.ColliderCreationMode.Trigger,
+            ServerOnlyTrigger => PrimitiveObject.ColliderCreationMode.ServerOnlyTrigger,
+            ServerOnlyNonSpawnedObject => PrimitiveObject.ColliderCreationMode.ServerOnlyNonSpawned,
             _ => PrimitiveObject.ColliderCreationMode.Unset
+        };
+
+        public static string GetModeDescription(PrimitiveObject.ColliderCreationMode mode, bool isHeader = false) => mode switch {
+            PrimitiveObject.ColliderCreationMode.NoCollider => DescriptionNoCollider,
+            PrimitiveObject.ColliderCreationMode.ClientOnly => DescriptionClientOnly,
+            PrimitiveObject.ColliderCreationMode.ServerOnlySpawned => DescriptionServerOnlySpawnedObject,
+            PrimitiveObject.ColliderCreationMode.Both => DescriptionBoth,
+            PrimitiveObject.ColliderCreationMode.Trigger => DescriptionTrigger,
+            PrimitiveObject.ColliderCreationMode.ServerOnlyTrigger => DescriptionServerOnlyTrigger,
+            PrimitiveObject.ColliderCreationMode.ServerOnlyNonSpawned => DescriptionServerOnlyNonSpawnedObject,
+            _ => isHeader ? DescriptionHeaderUnset : DescriptionUnset
         };
 
     }

--- a/Scripts/slocExporter/ExporterIgnored.cs
+++ b/Scripts/slocExporter/ExporterIgnored.cs
@@ -3,7 +3,7 @@
 namespace slocExporter {
 
     [DisallowMultipleComponent]
-    public class ExporterIgnored : MonoBehaviour {
+    public sealed class ExporterIgnored : MonoBehaviour {
 
     }
 

--- a/Scripts/slocExporter/Objects/EmptyObject.cs
+++ b/Scripts/slocExporter/Objects/EmptyObject.cs
@@ -1,6 +1,6 @@
 ﻿namespace slocExporter.Objects {
 
-    public class EmptyObject : slocGameObject {
+    public sealed class EmptyObject : slocGameObject {
 
         public EmptyObject(int instanceId) : base(instanceId) => Type = ObjectType.Empty;
 

--- a/Scripts/slocExporter/Objects/LightObject.cs
+++ b/Scripts/slocExporter/Objects/LightObject.cs
@@ -1,9 +1,10 @@
 ﻿using System.IO;
+using slocExporter.Readers;
 using UnityEngine;
 
 namespace slocExporter.Objects {
 
-    public class LightObject : slocGameObject {
+    public sealed class LightObject : slocGameObject {
 
         public LightObject(int instanceId) : base(instanceId) => Type = ObjectType.Light;
 
@@ -15,9 +16,9 @@ namespace slocExporter.Objects {
 
         public float Intensity = 1;
 
-        public override void WriteTo(BinaryWriter writer, slocAttributes attributes) {
-            base.WriteTo(writer, attributes);
-            if (attributes.HasFlagFast(slocAttributes.LossyColors))
+        public override void WriteTo(BinaryWriter writer, slocHeader header) {
+            base.WriteTo(writer, header);
+            if (header.HasAttribute(slocAttributes.LossyColors))
                 writer.Write(LightColor.ToLossyColor());
             else {
                 writer.Write(LightColor.r);

--- a/Scripts/slocExporter/Objects/LightObject.cs
+++ b/Scripts/slocExporter/Objects/LightObject.cs
@@ -17,10 +17,15 @@ namespace slocExporter.Objects {
 
         public override void WriteTo(BinaryWriter writer, slocAttributes attributes) {
             base.WriteTo(writer, attributes);
-            writer.Write(LightColor.r);
-            writer.Write(LightColor.g);
-            writer.Write(LightColor.b);
-            writer.Write(LightColor.a);
+            if (attributes.HasFlagFast(slocAttributes.LossyColors))
+                writer.Write(LightColor.ToLossyColor());
+            else {
+                writer.Write(LightColor.r);
+                writer.Write(LightColor.g);
+                writer.Write(LightColor.b);
+                writer.Write(LightColor.a);
+            }
+
             writer.Write(Shadows);
             writer.Write(Range);
             writer.Write(Intensity);

--- a/Scripts/slocExporter/Objects/LightObject.cs
+++ b/Scripts/slocExporter/Objects/LightObject.cs
@@ -15,8 +15,8 @@ namespace slocExporter.Objects {
 
         public float Intensity = 1;
 
-        public override void WriteTo(BinaryWriter writer) {
-            base.WriteTo(writer);
+        public override void WriteTo(BinaryWriter writer, slocAttributes attributes) {
+            base.WriteTo(writer, attributes);
             writer.Write(LightColor.r);
             writer.Write(LightColor.g);
             writer.Write(LightColor.b);

--- a/Scripts/slocExporter/Objects/PrimitiveObject.cs
+++ b/Scripts/slocExporter/Objects/PrimitiveObject.cs
@@ -39,11 +39,12 @@ namespace slocExporter.Objects {
             Unset = 0,
             NoCollider = 1,
             ClientOnly = 2,
-            ServerOnlySpawned = 3,
+            ServerOnly = 3,
             Both = 4,
             Trigger = 5,
-            ServerOnlyTrigger = 6,
-            ServerOnlyNonSpawned = 7
+            NonSpawnedTrigger = 6,
+            ServerOnlyNonSpawned = 7,
+            NoColliderNonSpawned = 8
 
         }
 

--- a/Scripts/slocExporter/Objects/PrimitiveObject.cs
+++ b/Scripts/slocExporter/Objects/PrimitiveObject.cs
@@ -7,15 +7,15 @@ namespace slocExporter.Objects {
     public class PrimitiveObject : slocGameObject {
 
         public PrimitiveObject(int instanceId, ObjectType type) : base(instanceId) {
-            if (type == ObjectType.None || type == ObjectType.Light)
+            if (type is ObjectType.None or ObjectType.Light)
                 throw new ArgumentException("Invalid primitive type", nameof(type));
             Type = type;
         }
 
         public Color MaterialColor;
 
-        public override void WriteTo(BinaryWriter writer) {
-            base.WriteTo(writer);
+        public override void WriteTo(BinaryWriter writer, slocAttributes attributes) {
+            base.WriteTo(writer, attributes);
             writer.Write(MaterialColor.r);
             writer.Write(MaterialColor.g);
             writer.Write(MaterialColor.b);

--- a/Scripts/slocExporter/Objects/PrimitiveObject.cs
+++ b/Scripts/slocExporter/Objects/PrimitiveObject.cs
@@ -14,17 +14,16 @@ namespace slocExporter.Objects {
         }
 
         public Color MaterialColor = Color.gray;
-        private ColliderCreationMode _colliderMode = ColliderCreationMode.Both;
 
-        public ColliderCreationMode ColliderMode {
-            get => _colliderMode;
-            set => _colliderMode = value is ColliderCreationMode.Unset ? _colliderMode : value;
-        }
+        public ColliderCreationMode ColliderMode { get; set; } = ColliderCreationMode.Both;
+
+        public ColliderCreationMode GetNonUnsetColliderMode() => ColliderMode is ColliderCreationMode.Unset ? ColliderCreationMode.Both : ColliderMode;
 
         public override void WriteTo(BinaryWriter writer, slocHeader header) {
             base.WriteTo(writer, header);
             if (header.HasAttribute(slocAttributes.LossyColors)) {
                 writer.Write(MaterialColor.ToLossyColor());
+                writer.Write((byte) ColliderMode);
                 return;
             }
 
@@ -32,8 +31,7 @@ namespace slocExporter.Objects {
             writer.Write(MaterialColor.g);
             writer.Write(MaterialColor.b);
             writer.Write(MaterialColor.a);
-            if (!header.HasAttribute(slocAttributes.ForcedColliderMode))
-                writer.Write((byte) ColliderMode);
+            writer.Write((byte) ColliderMode);
         }
 
         public enum ColliderCreationMode : byte {

--- a/Scripts/slocExporter/Objects/PrimitiveObject.cs
+++ b/Scripts/slocExporter/Objects/PrimitiveObject.cs
@@ -39,10 +39,11 @@ namespace slocExporter.Objects {
             Unset = 0,
             NoCollider = 1,
             ClientOnly = 2,
-            ServerOnly = 3,
+            ServerOnlySpawned = 3,
             Both = 4,
             Trigger = 5,
-            ServerOnlyTrigger = 6
+            ServerOnlyTrigger = 6,
+            ServerOnlyNonSpawned = 7
 
         }
 

--- a/Scripts/slocExporter/Objects/PrimitiveObject.cs
+++ b/Scripts/slocExporter/Objects/PrimitiveObject.cs
@@ -16,6 +16,11 @@ namespace slocExporter.Objects {
 
         public override void WriteTo(BinaryWriter writer, slocAttributes attributes) {
             base.WriteTo(writer, attributes);
+            if (attributes.HasFlagFast(slocAttributes.LossyColors)) {
+                writer.Write(MaterialColor.ToLossyColor());
+                return;
+            }
+
             writer.Write(MaterialColor.r);
             writer.Write(MaterialColor.g);
             writer.Write(MaterialColor.b);

--- a/Scripts/slocExporter/Objects/slocGameObject.cs
+++ b/Scripts/slocExporter/Objects/slocGameObject.cs
@@ -1,4 +1,5 @@
 ﻿using System.IO;
+using slocExporter.Readers;
 
 namespace slocExporter.Objects {
 
@@ -17,7 +18,7 @@ namespace slocExporter.Objects {
 
         public virtual bool IsValid => Type != ObjectType.None;
 
-        public virtual void WriteTo(BinaryWriter writer, slocAttributes attributes) {
+        public virtual void WriteTo(BinaryWriter writer, slocHeader header) {
             writer.Write((byte) Type);
             writer.Write(InstanceId);
             writer.Write(ParentId);

--- a/Scripts/slocExporter/Objects/slocGameObject.cs
+++ b/Scripts/slocExporter/Objects/slocGameObject.cs
@@ -13,11 +13,11 @@ namespace slocExporter.Objects {
         public bool HasParent => ParentId != InstanceId;
 
         public ObjectType Type { get; protected set; } = ObjectType.None;
-        public slocTransform Transform = new slocTransform();
+        public slocTransform Transform = new();
 
         public virtual bool IsValid => Type != ObjectType.None;
 
-        public virtual void WriteTo(BinaryWriter writer) {
+        public virtual void WriteTo(BinaryWriter writer, slocAttributes attributes) {
             writer.Write((byte) Type);
             writer.Write(InstanceId);
             writer.Write(ParentId);

--- a/Scripts/slocExporter/Objects/slocTransform.cs
+++ b/Scripts/slocExporter/Objects/slocTransform.cs
@@ -22,7 +22,7 @@ namespace slocExporter.Objects {
             writer.Write(Rotation.w);
         }
 
-        public static implicit operator slocTransform(Transform transform) => new slocTransform {
+        public static implicit operator slocTransform(Transform transform) => new() {
             Position = transform.localPosition,
             Scale = transform.localScale,
             Rotation = transform.localRotation

--- a/Scripts/slocExporter/Objects/slocTransform.cs
+++ b/Scripts/slocExporter/Objects/slocTransform.cs
@@ -3,7 +3,7 @@ using UnityEngine;
 
 namespace slocExporter.Objects {
 
-    public class slocTransform {
+    public sealed class slocTransform {
 
         public Vector3 Position = Vector3.zero;
         public Vector3 Scale = Vector3.one;
@@ -22,7 +22,7 @@ namespace slocExporter.Objects {
             writer.Write(Rotation.w);
         }
 
-        public static implicit operator slocTransform(Transform transform) => new() {
+        public static implicit operator slocTransform(Transform transform) => new slocTransform {
             Position = transform.localPosition,
             Scale = transform.localScale,
             Rotation = transform.localRotation

--- a/Scripts/slocExporter/Readers/IObjectReader.cs
+++ b/Scripts/slocExporter/Readers/IObjectReader.cs
@@ -5,7 +5,9 @@ namespace slocExporter.Readers {
 
     public interface IObjectReader {
 
-        slocGameObject Read(BinaryReader stream);
+        slocHeader ReadHeader(BinaryReader stream);
+        
+        slocGameObject Read(BinaryReader stream, slocAttributes attributes);
 
     }
 

--- a/Scripts/slocExporter/Readers/IObjectReader.cs
+++ b/Scripts/slocExporter/Readers/IObjectReader.cs
@@ -7,7 +7,7 @@ namespace slocExporter.Readers {
 
         slocHeader ReadHeader(BinaryReader stream);
         
-        slocGameObject Read(BinaryReader stream, slocAttributes attributes);
+        slocGameObject Read(BinaryReader stream, slocHeader header);
 
     }
 

--- a/Scripts/slocExporter/Readers/Ver1Reader.cs
+++ b/Scripts/slocExporter/Readers/Ver1Reader.cs
@@ -5,7 +5,9 @@ namespace slocExporter.Readers {
 
     public class Ver1Reader : IObjectReader {
 
-        public slocGameObject Read(BinaryReader stream) {
+        public slocHeader ReadHeader(BinaryReader stream) => new(stream.ReadInt32());
+
+        public slocGameObject Read(BinaryReader stream, slocAttributes attributes) {
             var objectType = (ObjectType) stream.ReadByte();
             return objectType switch {
                 ObjectType.Cube => ReadPrimitive(stream, objectType),
@@ -18,12 +20,12 @@ namespace slocExporter.Readers {
             };
         }
 
-        private static slocGameObject ReadPrimitive(BinaryReader stream, ObjectType type) => new PrimitiveObject(0, type) {
+        public static slocGameObject ReadPrimitive(BinaryReader stream, ObjectType type) => new PrimitiveObject(0, type) {
             Transform = stream.ReadTransform(),
             MaterialColor = stream.ReadColor()
         };
 
-        private static slocGameObject ReadLight(BinaryReader stream) => new LightObject(0) {
+        public static slocGameObject ReadLight(BinaryReader stream) => new LightObject(0) {
             Transform = stream.ReadTransform(),
             LightColor = stream.ReadColor(),
             Shadows = stream.ReadBoolean(),

--- a/Scripts/slocExporter/Readers/Ver1Reader.cs
+++ b/Scripts/slocExporter/Readers/Ver1Reader.cs
@@ -20,18 +20,35 @@ namespace slocExporter.Readers {
             };
         }
 
-        public static slocGameObject ReadPrimitive(BinaryReader stream, ObjectType type) => new PrimitiveObject(0, type) {
-            Transform = stream.ReadTransform(),
-            MaterialColor = stream.ReadColor()
-        };
+        public static slocGameObject ReadPrimitive(BinaryReader stream, ObjectType type) {
+            var instanceId = stream.ReadInt32();
+            var parentId = stream.ReadInt32();
+            var transform = stream.ReadTransform();
+            var materialColor = stream.ReadColor();
+            return new PrimitiveObject(instanceId, type) {
+                ParentId = parentId,
+                Transform = transform,
+                MaterialColor = materialColor
+            };
+        }
 
-        public static slocGameObject ReadLight(BinaryReader stream) => new LightObject(0) {
-            Transform = stream.ReadTransform(),
-            LightColor = stream.ReadColor(),
-            Shadows = stream.ReadBoolean(),
-            Range = stream.ReadSingle(),
-            Intensity = stream.ReadSingle(),
-        };
+        public static slocGameObject ReadLight(BinaryReader stream) {
+            var instanceId = stream.ReadInt32();
+            var parentId = stream.ReadInt32();
+            var transform = stream.ReadTransform();
+            var lightColor = stream.ReadColor();
+            var shadows = stream.ReadBoolean();
+            var range = stream.ReadSingle();
+            var intensity = stream.ReadSingle();
+            return new LightObject(instanceId) {
+                ParentId = parentId,
+                Transform = transform,
+                LightColor = lightColor,
+                Shadows = shadows,
+                Range = range,
+                Intensity = intensity,
+            };
+        }
 
     }
 

--- a/Scripts/slocExporter/Readers/Ver1Reader.cs
+++ b/Scripts/slocExporter/Readers/Ver1Reader.cs
@@ -21,27 +21,21 @@ namespace slocExporter.Readers {
         }
 
         public static slocGameObject ReadPrimitive(BinaryReader stream, ObjectType type) {
-            var instanceId = stream.ReadInt32();
-            var parentId = stream.ReadInt32();
             var transform = stream.ReadTransform();
             var materialColor = stream.ReadColor();
-            return new PrimitiveObject(instanceId, type) {
-                ParentId = parentId,
+            return new PrimitiveObject(0, type) {
                 Transform = transform,
                 MaterialColor = materialColor
             };
         }
 
         public static slocGameObject ReadLight(BinaryReader stream) {
-            var instanceId = stream.ReadInt32();
-            var parentId = stream.ReadInt32();
             var transform = stream.ReadTransform();
             var lightColor = stream.ReadColor();
             var shadows = stream.ReadBoolean();
             var range = stream.ReadSingle();
             var intensity = stream.ReadSingle();
-            return new LightObject(instanceId) {
-                ParentId = parentId,
+            return new LightObject(0) {
                 Transform = transform,
                 LightColor = lightColor,
                 Shadows = shadows,

--- a/Scripts/slocExporter/Readers/Ver1Reader.cs
+++ b/Scripts/slocExporter/Readers/Ver1Reader.cs
@@ -3,11 +3,11 @@ using slocExporter.Objects;
 
 namespace slocExporter.Readers {
 
-    public class Ver1Reader : IObjectReader {
+    public sealed class Ver1Reader : IObjectReader {
 
-        public slocHeader ReadHeader(BinaryReader stream) => new(stream.ReadInt32());
+        public slocHeader ReadHeader(BinaryReader stream) => new(stream.ReadObjectCount());
 
-        public slocGameObject Read(BinaryReader stream, slocAttributes attributes) {
+        public slocGameObject Read(BinaryReader stream, slocHeader header) {
             var objectType = (ObjectType) stream.ReadByte();
             return objectType switch {
                 ObjectType.Cube => ReadPrimitive(stream, objectType),

--- a/Scripts/slocExporter/Readers/Ver2Reader.cs
+++ b/Scripts/slocExporter/Readers/Ver2Reader.cs
@@ -10,20 +10,50 @@ namespace slocExporter.Readers {
         public slocGameObject Read(BinaryReader stream, slocHeader header) {
             var objectType = (ObjectType) stream.ReadByte();
             return objectType switch {
-                ObjectType.Cube => Ver1Reader.ReadPrimitive(stream, objectType),
-                ObjectType.Sphere => Ver1Reader.ReadPrimitive(stream, objectType),
-                ObjectType.Cylinder => Ver1Reader.ReadPrimitive(stream, objectType),
-                ObjectType.Plane => Ver1Reader.ReadPrimitive(stream, objectType),
-                ObjectType.Capsule => Ver1Reader.ReadPrimitive(stream, objectType),
-                ObjectType.Light => Ver1Reader.ReadLight(stream),
+                ObjectType.Cube => ReadPrimitive(stream, objectType),
+                ObjectType.Sphere => ReadPrimitive(stream, objectType),
+                ObjectType.Cylinder => ReadPrimitive(stream, objectType),
+                ObjectType.Plane => ReadPrimitive(stream, objectType),
+                ObjectType.Capsule => ReadPrimitive(stream, objectType),
+                ObjectType.Light => ReadLight(stream),
                 ObjectType.Empty => ReadEmpty(stream),
                 _ => null
             };
         }
 
+        public static slocGameObject ReadPrimitive(BinaryReader stream, ObjectType type) {
+            var instanceId = stream.ReadInt32();
+            var parentId = stream.ReadInt32();
+            var transform = stream.ReadTransform();
+            var materialColor = stream.ReadColor();
+            return new PrimitiveObject(instanceId, type) {
+                ParentId = parentId,
+                Transform = transform,
+                MaterialColor = materialColor
+            };
+        }
+
+        public static slocGameObject ReadLight(BinaryReader stream) {
+            var instanceId = stream.ReadInt32();
+            var parentId = stream.ReadInt32();
+            var transform = stream.ReadTransform();
+            var lightColor = stream.ReadColor();
+            var shadows = stream.ReadBoolean();
+            var range = stream.ReadSingle();
+            var intensity = stream.ReadSingle();
+            return new LightObject(instanceId) {
+                ParentId = parentId,
+                Transform = transform,
+                LightColor = lightColor,
+                Shadows = shadows,
+                Range = range,
+                Intensity = intensity,
+            };
+        }
+
         public static slocGameObject ReadEmpty(BinaryReader stream) {
             var instanceId = stream.ReadInt32();
-            int parentId = stream.ReadInt32();
+            var parentId = stream.ReadInt32();
             var transform = stream.ReadTransform();
             return new EmptyObject(instanceId) {
                 ParentId = parentId,

--- a/Scripts/slocExporter/Readers/Ver2Reader.cs
+++ b/Scripts/slocExporter/Readers/Ver2Reader.cs
@@ -10,36 +10,26 @@ namespace slocExporter.Readers {
         public slocGameObject Read(BinaryReader stream, slocHeader header) {
             var objectType = (ObjectType) stream.ReadByte();
             return objectType switch {
-                ObjectType.Cube => ReadPrimitive(stream, objectType),
-                ObjectType.Sphere => ReadPrimitive(stream, objectType),
-                ObjectType.Cylinder => ReadPrimitive(stream, objectType),
-                ObjectType.Plane => ReadPrimitive(stream, objectType),
-                ObjectType.Capsule => ReadPrimitive(stream, objectType),
-                ObjectType.Light => ReadLight(stream),
+                ObjectType.Cube => Ver1Reader.ReadPrimitive(stream, objectType),
+                ObjectType.Sphere => Ver1Reader.ReadPrimitive(stream, objectType),
+                ObjectType.Cylinder => Ver1Reader.ReadPrimitive(stream, objectType),
+                ObjectType.Plane => Ver1Reader.ReadPrimitive(stream, objectType),
+                ObjectType.Capsule => Ver1Reader.ReadPrimitive(stream, objectType),
+                ObjectType.Light => Ver1Reader.ReadLight(stream),
                 ObjectType.Empty => ReadEmpty(stream),
                 _ => null
             };
         }
 
-        public static slocGameObject ReadPrimitive(BinaryReader stream, ObjectType type) => new PrimitiveObject(stream.ReadInt32(), type) {
-            ParentId = stream.ReadInt32(),
-            Transform = stream.ReadTransform(),
-            MaterialColor = stream.ReadColor()
-        };
-
-        public static slocGameObject ReadLight(BinaryReader stream) => new LightObject(stream.ReadInt32()) {
-            ParentId = stream.ReadInt32(),
-            Transform = stream.ReadTransform(),
-            LightColor = stream.ReadColor(),
-            Shadows = stream.ReadBoolean(),
-            Range = stream.ReadSingle(),
-            Intensity = stream.ReadSingle(),
-        };
-
-        public static slocGameObject ReadEmpty(BinaryReader stream) => new EmptyObject(stream.ReadInt32()) {
-            ParentId = stream.ReadInt32(),
-            Transform = stream.ReadTransform()
-        };
+        public static slocGameObject ReadEmpty(BinaryReader stream) {
+            var instanceId = stream.ReadInt32();
+            int parentId = stream.ReadInt32();
+            var transform = stream.ReadTransform();
+            return new EmptyObject(instanceId) {
+                ParentId = parentId,
+                Transform = transform
+            };
+        }
 
     }
 

--- a/Scripts/slocExporter/Readers/Ver2Reader.cs
+++ b/Scripts/slocExporter/Readers/Ver2Reader.cs
@@ -5,7 +5,9 @@ namespace slocExporter.Readers {
 
     public class Ver2Reader : IObjectReader {
 
-        public slocGameObject Read(BinaryReader stream) {
+        public slocHeader ReadHeader(BinaryReader stream) => new(stream.ReadInt32());
+
+        public slocGameObject Read(BinaryReader stream, slocAttributes attributes) {
             var objectType = (ObjectType) stream.ReadByte();
             return objectType switch {
                 ObjectType.Cube => ReadPrimitive(stream, objectType),
@@ -19,13 +21,13 @@ namespace slocExporter.Readers {
             };
         }
 
-        private static slocGameObject ReadPrimitive(BinaryReader stream, ObjectType type) => new PrimitiveObject(stream.ReadInt32(), type) {
+        public static slocGameObject ReadPrimitive(BinaryReader stream, ObjectType type) => new PrimitiveObject(stream.ReadInt32(), type) {
             ParentId = stream.ReadInt32(),
             Transform = stream.ReadTransform(),
             MaterialColor = stream.ReadColor()
         };
 
-        private static slocGameObject ReadLight(BinaryReader stream) => new LightObject(stream.ReadInt32()) {
+        public static slocGameObject ReadLight(BinaryReader stream) => new LightObject(stream.ReadInt32()) {
             ParentId = stream.ReadInt32(),
             Transform = stream.ReadTransform(),
             LightColor = stream.ReadColor(),
@@ -34,7 +36,7 @@ namespace slocExporter.Readers {
             Intensity = stream.ReadSingle(),
         };
 
-        private static slocGameObject ReadEmpty(BinaryReader stream) => new EmptyObject(stream.ReadInt32()) {
+        public static slocGameObject ReadEmpty(BinaryReader stream) => new EmptyObject(stream.ReadInt32()) {
             ParentId = stream.ReadInt32(),
             Transform = stream.ReadTransform()
         };

--- a/Scripts/slocExporter/Readers/Ver2Reader.cs
+++ b/Scripts/slocExporter/Readers/Ver2Reader.cs
@@ -3,11 +3,11 @@ using slocExporter.Objects;
 
 namespace slocExporter.Readers {
 
-    public class Ver2Reader : IObjectReader {
+    public sealed class Ver2Reader : IObjectReader {
 
-        public slocHeader ReadHeader(BinaryReader stream) => new(stream.ReadInt32());
+        public slocHeader ReadHeader(BinaryReader stream) => new(stream.ReadObjectCount());
 
-        public slocGameObject Read(BinaryReader stream, slocAttributes attributes) {
+        public slocGameObject Read(BinaryReader stream, slocHeader header) {
             var objectType = (ObjectType) stream.ReadByte();
             return objectType switch {
                 ObjectType.Cube => ReadPrimitive(stream, objectType),

--- a/Scripts/slocExporter/Readers/Ver3Reader.cs
+++ b/Scripts/slocExporter/Readers/Ver3Reader.cs
@@ -1,0 +1,46 @@
+﻿using System.IO;
+using slocExporter.Objects;
+
+namespace slocExporter.Readers {
+
+    public class Ver3Reader : IObjectReader {
+
+        public slocHeader ReadHeader(BinaryReader stream) => new(stream.ReadInt32(), stream.ReadByte());
+
+        public slocGameObject Read(BinaryReader stream, slocAttributes attributes) {
+            var objectType = (ObjectType) stream.ReadByte();
+            return objectType switch {
+                ObjectType.Cube => ReadPrimitive(stream, objectType, attributes),
+                ObjectType.Sphere => ReadPrimitive(stream, objectType, attributes),
+                ObjectType.Cylinder => ReadPrimitive(stream, objectType, attributes),
+                ObjectType.Plane => ReadPrimitive(stream, objectType, attributes),
+                ObjectType.Capsule => ReadPrimitive(stream, objectType, attributes),
+                ObjectType.Light => ReadLight(stream, attributes),
+                ObjectType.Empty => ReadEmpty(stream),
+                _ => null
+            };
+        }
+
+        public static slocGameObject ReadPrimitive(BinaryReader stream, ObjectType type, slocAttributes attributes) => new PrimitiveObject(stream.ReadInt32(), type) {
+            ParentId = stream.ReadInt32(),
+            Transform = stream.ReadTransform(),
+            MaterialColor = attributes.HasFlagFast(slocAttributes.LossyColors) ? stream.ReadLossyColor() : stream.ReadColor()
+        };
+
+        public static slocGameObject ReadLight(BinaryReader stream, slocAttributes attributes) => new LightObject(stream.ReadInt32()) {
+            ParentId = stream.ReadInt32(),
+            Transform = stream.ReadTransform(),
+            LightColor = attributes.HasFlagFast(slocAttributes.LossyColors) ? stream.ReadLossyColor() : stream.ReadColor(),
+            Shadows = stream.ReadBoolean(),
+            Range = stream.ReadSingle(),
+            Intensity = stream.ReadSingle(),
+        };
+
+        public static slocGameObject ReadEmpty(BinaryReader stream) => new EmptyObject(stream.ReadInt32()) {
+            ParentId = stream.ReadInt32(),
+            Transform = stream.ReadTransform()
+        };
+
+    }
+
+}

--- a/Scripts/slocExporter/Readers/Ver3Reader.cs
+++ b/Scripts/slocExporter/Readers/Ver3Reader.cs
@@ -11,7 +11,7 @@ namespace slocExporter.Readers {
             var attributes = (slocAttributes) stream.ReadByte();
             return new slocHeader(count,
                 attributes,
-                attributes.HasFlagFast(slocAttributes.ForcedColliderMode)
+                attributes.HasFlagFast(slocAttributes.DefaultColliderMode)
                     ? (PrimitiveObject.ColliderCreationMode) stream.ReadByte()
                     : PrimitiveObject.ColliderCreationMode.Unset
             );
@@ -26,7 +26,7 @@ namespace slocExporter.Readers {
                 ObjectType.Plane => ReadPrimitive(stream, objectType, header),
                 ObjectType.Capsule => ReadPrimitive(stream, objectType, header),
                 ObjectType.Light => ReadLight(stream, header),
-                ObjectType.Empty => ReadEmpty(stream),
+                ObjectType.Empty => Ver2Reader.ReadEmpty(stream),
                 _ => null
             };
         }
@@ -36,9 +36,10 @@ namespace slocExporter.Readers {
             var parentId = stream.ReadInt32();
             var slocTransform = stream.ReadTransform();
             var color = ReadColor(stream, header.HasAttribute(slocAttributes.LossyColors));
-            var creationMode = header.HasAttribute(slocAttributes.ForcedColliderMode)
+            var colliderCreationMode = (PrimitiveObject.ColliderCreationMode) stream.ReadByte();
+            var creationMode = colliderCreationMode is PrimitiveObject.ColliderCreationMode.Unset && header.HasAttribute(slocAttributes.DefaultColliderMode)
                 ? header.DefaultColliderMode
-                : (PrimitiveObject.ColliderCreationMode) stream.ReadByte();
+                : colliderCreationMode;
             return new PrimitiveObject(instanceId, type) {
                 ParentId = parentId,
                 Transform = slocTransform,
@@ -47,21 +48,25 @@ namespace slocExporter.Readers {
             };
         }
 
-        public static slocGameObject ReadLight(BinaryReader stream, slocHeader header) => new LightObject(stream.ReadInt32()) {
-            ParentId = stream.ReadInt32(),
-            Transform = stream.ReadTransform(),
-            LightColor = ReadColor(stream, header.HasAttribute(slocAttributes.LossyColors)),
-            Shadows = stream.ReadBoolean(),
-            Range = stream.ReadSingle(),
-            Intensity = stream.ReadSingle(),
-        };
+        public static slocGameObject ReadLight(BinaryReader stream, slocHeader header) {
+            var instanceId = stream.ReadInt32();
+            var parentId = stream.ReadInt32();
+            var transform = stream.ReadTransform();
+            var lightColor = ReadColor(stream, header.HasAttribute(slocAttributes.LossyColors));
+            var shadows = stream.ReadBoolean();
+            var range = stream.ReadSingle();
+            var intensity = stream.ReadSingle();
+            return new LightObject(instanceId) {
+                ParentId = parentId,
+                Transform = transform,
+                LightColor = lightColor,
+                Shadows = shadows,
+                Range = range,
+                Intensity = intensity,
+            };
+        }
 
         public static Color ReadColor(BinaryReader stream, bool lossy) => lossy ? stream.ReadLossyColor() : stream.ReadColor();
-
-        public static slocGameObject ReadEmpty(BinaryReader stream) => new EmptyObject(stream.ReadInt32()) {
-            ParentId = stream.ReadInt32(),
-            Transform = stream.ReadTransform()
-        };
 
     }
 

--- a/Scripts/slocExporter/Readers/Ver3Reader.cs
+++ b/Scripts/slocExporter/Readers/Ver3Reader.cs
@@ -9,11 +9,12 @@ namespace slocExporter.Readers {
         public slocHeader ReadHeader(BinaryReader stream) {
             var count = stream.ReadObjectCount();
             var attributes = (slocAttributes) stream.ReadByte();
+            var colliderCreationMode = attributes.HasFlagFast(slocAttributes.DefaultColliderMode)
+                ? (PrimitiveObject.ColliderCreationMode) stream.ReadByte()
+                : PrimitiveObject.ColliderCreationMode.Unset;
             return new slocHeader(count,
                 attributes,
-                attributes.HasFlagFast(slocAttributes.DefaultColliderMode)
-                    ? (PrimitiveObject.ColliderCreationMode) stream.ReadByte()
-                    : PrimitiveObject.ColliderCreationMode.Unset
+                colliderCreationMode
             );
         }
 

--- a/Scripts/slocExporter/Readers/slocHeader.cs
+++ b/Scripts/slocExporter/Readers/slocHeader.cs
@@ -1,4 +1,5 @@
 ﻿using System.IO;
+using slocExporter.Objects;
 
 namespace slocExporter.Readers {
 
@@ -8,19 +9,25 @@ namespace slocExporter.Readers {
 
         public readonly slocAttributes Attributes;
 
-        public slocHeader(int objectCount, slocAttributes attributes = slocAttributes.None) {
+        public readonly PrimitiveObject.ColliderCreationMode DefaultColliderMode;
+
+        public slocHeader(int objectCount, slocAttributes attributes = slocAttributes.None, PrimitiveObject.ColliderCreationMode defaultColliderMode = PrimitiveObject.ColliderCreationMode.Unset) {
             ObjectCount = objectCount;
             Attributes = attributes;
+            DefaultColliderMode = defaultColliderMode;
         }
 
-        public slocHeader(int objectCount, byte attributes) {
+        public slocHeader(int objectCount, byte attributes, PrimitiveObject.ColliderCreationMode defaultColliderMode = PrimitiveObject.ColliderCreationMode.Unset) {
             ObjectCount = objectCount;
             Attributes = (slocAttributes) attributes;
+            DefaultColliderMode = defaultColliderMode;
         }
 
         public void WriteTo(BinaryWriter writer) {
             writer.Write(ObjectCount);
             writer.Write((byte) Attributes);
+            if (Attributes.HasFlagFast(slocAttributes.ForcedColliderMode))
+                writer.Write((byte) DefaultColliderMode);
         }
 
     }

--- a/Scripts/slocExporter/Readers/slocHeader.cs
+++ b/Scripts/slocExporter/Readers/slocHeader.cs
@@ -26,7 +26,7 @@ namespace slocExporter.Readers {
         public void WriteTo(BinaryWriter writer) {
             writer.Write(ObjectCount);
             writer.Write((byte) Attributes);
-            if (Attributes.HasFlagFast(slocAttributes.ForcedColliderMode))
+            if (Attributes.HasFlagFast(slocAttributes.DefaultColliderMode))
                 writer.Write((byte) DefaultColliderMode);
         }
 

--- a/Scripts/slocExporter/Readers/slocHeader.cs
+++ b/Scripts/slocExporter/Readers/slocHeader.cs
@@ -1,0 +1,28 @@
+﻿using System.IO;
+
+namespace slocExporter.Readers {
+
+    public readonly struct slocHeader {
+
+        public readonly int ObjectCount;
+
+        public readonly slocAttributes Attributes;
+
+        public slocHeader(int objectCount, slocAttributes attributes = slocAttributes.None) {
+            ObjectCount = objectCount;
+            Attributes = attributes;
+        }
+
+        public slocHeader(int objectCount, byte attributes) {
+            ObjectCount = objectCount;
+            Attributes = (slocAttributes) attributes;
+        }
+
+        public void WriteTo(BinaryWriter writer) {
+            writer.Write(ObjectCount);
+            writer.Write((byte) Attributes);
+        }
+
+    }
+
+}

--- a/Scripts/slocExporter/slocAttributes.cs
+++ b/Scripts/slocExporter/slocAttributes.cs
@@ -7,7 +7,7 @@ namespace slocExporter {
 
         None = 0,
         LossyColors = 1,
-        ForcedColliderMode = 2,
+        DefaultColliderMode = 2,
 
     }
 

--- a/Scripts/slocExporter/slocAttributes.cs
+++ b/Scripts/slocExporter/slocAttributes.cs
@@ -1,0 +1,13 @@
+﻿using System;
+
+namespace slocExporter {
+
+    [Flags]
+    public enum slocAttributes : byte {
+
+        None = 0,
+        LossyColors = 1,
+
+    }
+
+}

--- a/Scripts/slocExporter/slocAttributes.cs
+++ b/Scripts/slocExporter/slocAttributes.cs
@@ -7,6 +7,7 @@ namespace slocExporter {
 
         None = 0,
         LossyColors = 1,
+        ForcedColliderMode = 2,
 
     }
 

--- a/Scripts/slocImporter.cs
+++ b/Scripts/slocImporter.cs
@@ -6,14 +6,20 @@ using UnityEngine;
 
 public static class slocImporter {
 
-    public static bool Init(string filePath) {
+    public static bool Init(string filePath, bool useExistingMaterials, bool colorsFolderOnly) {
         if (_inProgress)
             return false;
         _filePath = filePath;
+        UseExistingMaterials = useExistingMaterials;
+        SearchInColorsFolderOnly = colorsFolderOnly;
         return true;
     }
 
     private static string _filePath = "";
+
+    public static bool UseExistingMaterials = true;
+    
+    public static bool SearchInColorsFolderOnly;
 
     private static bool _inProgress;
 


### PR DESCRIPTION
This version introduces attributes and colliders to sloc.

# Additions:
- Collider Mode editor
- Added tooltips to the Exporter Window
- Option to use existing materials in the Importer
- Collider Modes for primitive objects
- **slocHeader** struct
- **GetNonUnsetColliderMode()** method in **PrimitiveObject**
- **Read(BinaryReader)** method in **IObjectReader** and implementations
- **Ver3Reader**
- API methods: **ReadLossyColor**, **ReadObjectCount**, **ToRgbRange**, **ToLossyColor**, **HasFlagFast**, **HasAttribute**
- **slocAttributes** enum
- **Collider Mode Setter** script

# Changes (breaking):
- Added argument **slocHeader header** to the method **slocGameObject.WriteTo** and its implementations
- Added argument **slocHeader header** to the method **IObjectReader.Read** and its implementations
- Added argument **slocHeader header** to the method **API.ReadObject**
- Version number is now an **ushort** instead of an **uint**; affected methods: **API.TryGetReader**, **API.GetReader**, **API.ReadObject**

# Changes (non-breaking):
- Made the RegisterTag class sealed
- Made object classes sealed
- The default color of PrimitveObjects is now gray
- Moved all reads out of initializers in readers