### PR TITLE
v5: structures

### DIFF
--- a/Editor/RegisterTag.cs
+++ b/Editor/RegisterTag.cs
@@ -1,13 +1,16 @@
 ﻿using UnityEditor;
 
-namespace Editor {
+namespace Editor
+{
 
     [InitializeOnLoad]
-    public sealed class RegisterTag {
+    public sealed class RegisterTag
+    {
 
         static RegisterTag() => AddTag(ObjectExporter.ExporterIgnoredTag);
 
-        private static void AddTag(string tagName) {
+        private static void AddTag(string tagName)
+        {
             var tagManager = new SerializedObject(AssetDatabase.LoadAllAssetsAtPath("ProjectSettings/TagManager.asset")[0]);
             var tagsProp = tagManager.FindProperty("tags");
             if (PropertyExists(tagsProp, 0, tagsProp.arraySize, tagName))
@@ -19,8 +22,10 @@ namespace Editor {
             tagManager.ApplyModifiedProperties();
         }
 
-        private static bool PropertyExists(SerializedProperty property, int start, int end, string value) {
-            for (var i = start; i < end; i++) {
+        private static bool PropertyExists(SerializedProperty property, int start, int end, string value)
+        {
+            for (var i = start; i < end; i++)
+            {
                 var t = property.GetArrayElementAtIndex(i);
                 if (value.Equals(t.stringValue))
                     return true;

--- a/Editor/Updater/Constants.cs
+++ b/Editor/Updater/Constants.cs
@@ -1,6 +1,8 @@
-﻿namespace Editor.Updater {
+﻿namespace Editor.Updater
+{
 
-    internal static class Constants {
+    internal static class Constants
+    {
 
         private const string ApiUrlFormat = "https://api.github.com/repos/{0}/{1}/";
 

--- a/Editor/Updater/FileModification.cs
+++ b/Editor/Updater/FileModification.cs
@@ -5,42 +5,50 @@ using System.Linq;
 using Editor.Updater.Responses;
 using UnityEngine;
 
-namespace Editor.Updater {
+namespace Editor.Updater
+{
 
     [Serializable]
-    public struct FileModification {
+    public struct FileModification
+    {
 
         public string path;
 
         public bool removed;
 
-        public FileModification(string path, bool removed) {
+        public FileModification(string path, bool removed)
+        {
             this.path = path;
             this.removed = removed;
         }
 
-        private static bool IsTopLevelDirectory(ZipArchiveEntry arg) {
+        private static bool IsTopLevelDirectory(ZipArchiveEntry arg)
+        {
             var path = arg.FullName;
             var index = path.IndexOf('/');
             return index == -1 || index == path.Length - 1;
         }
 
-        public static void PatchFiles(ProgressUpdater update, ChangedFile[] files, string assets) {
+        public static void PatchFiles(ProgressUpdater update, ChangedFile[] files, string assets)
+        {
             using var zip = ZipFile.OpenRead(Constants.ArchiveFileName);
             var topDirectory = zip.Entries.FirstOrDefault(IsTopLevelDirectory);
-            if (topDirectory == null) {
+            if (topDirectory == null)
+            {
                 Debug.LogWarning("[slocUpdater] Could not find top directory in archive");
                 return;
             }
 
             var count = files.Length;
             var fc = (float) count;
-            for (var i = 0; i < count; i++) {
+            for (var i = 0; i < count; i++)
+            {
                 var file = files[i];
                 var wasRemoved = file.status is "removed";
                 var name = file.filename;
                 var entry = wasRemoved ? null : zip.GetEntry(topDirectory + name);
-                if (!wasRemoved && entry == null) {
+                if (!wasRemoved && entry == null)
+                {
                     Debug.LogWarning($"[slocUpdater] Could not find entry {name} in archive");
                     continue;
                 }
@@ -50,15 +58,19 @@ namespace Editor.Updater {
             }
         }
 
-        private static void ProcessPatch(ChangedFile file, ZipArchiveEntry entry, bool wasRemoved, string assets) {
+        private static void ProcessPatch(ChangedFile file, ZipArchiveEntry entry, bool wasRemoved, string assets)
+        {
             var path = Path.Combine(assets, file.filename);
-            if (wasRemoved) {
+            if (wasRemoved)
+            {
                 if (File.Exists(path))
                     File.Delete(path);
                 else
                     Debug.LogWarning($"[slocUpdater] Could not find file {file.filename} to remove");
                 RemoveMetaFile(path);
-            } else {
+            }
+            else
+            {
                 var directory = Path.GetDirectoryName(path);
                 if (string.IsNullOrEmpty(directory))
                     return;
@@ -68,7 +80,8 @@ namespace Editor.Updater {
             }
         }
 
-        private static void RemoveMetaFile(string file) {
+        private static void RemoveMetaFile(string file)
+        {
             var metaFile = file + ".meta";
             if (File.Exists(metaFile))
                 File.Delete(metaFile);

--- a/Editor/Updater/Responses/ChangesResponse.cs
+++ b/Editor/Updater/Responses/ChangesResponse.cs
@@ -1,9 +1,11 @@
 ﻿using System;
 
-namespace Editor.Updater.Responses {
+namespace Editor.Updater.Responses
+{
 
     [Serializable]
-    public struct ChangesResponse {
+    public struct ChangesResponse
+    {
 
         public ChangedFile[] files;
 
@@ -12,7 +14,8 @@ namespace Editor.Updater.Responses {
     }
 
     [Serializable]
-    public struct ChangedFile {
+    public struct ChangedFile
+    {
 
         public string filename;
 

--- a/Editor/Updater/Responses/ErrorMessage.cs
+++ b/Editor/Updater/Responses/ErrorMessage.cs
@@ -1,9 +1,11 @@
 ﻿using System;
 
-namespace Editor.Updater.Responses {
+namespace Editor.Updater.Responses
+{
 
     [Serializable]
-    public struct ErrorMessage {
+    public struct ErrorMessage
+    {
 
         public string message;
 

--- a/Editor/Updater/Responses/ResponseArray.cs
+++ b/Editor/Updater/Responses/ResponseArray.cs
@@ -1,10 +1,12 @@
 ﻿using System;
 using UnityEngine;
 
-namespace Editor.Updater.Responses {
+namespace Editor.Updater.Responses
+{
 
     [Serializable]
-    public struct ResponseArray<T> {
+    public struct ResponseArray<T>
+    {
 
         public T[] items;
 

--- a/Editor/Updater/Responses/TagResponse.cs
+++ b/Editor/Updater/Responses/TagResponse.cs
@@ -1,9 +1,11 @@
 ﻿using System;
 
-namespace Editor.Updater.Responses {
+namespace Editor.Updater.Responses
+{
 
     [Serializable]
-    public struct TagResponse {
+    public struct TagResponse
+    {
 
         public string name;
 

--- a/Editor/Updater/UpdaterWindow.cs
+++ b/Editor/Updater/UpdaterWindow.cs
@@ -2,19 +2,25 @@
 using UnityEditor;
 using UnityEngine;
 
-namespace Editor.Updater {
+namespace Editor.Updater
+{
 
-    public sealed class UpdaterWindow : EditorWindow {
+    public sealed class UpdaterWindow : EditorWindow
+    {
 
         private const string CheckForUpdatesFile = "slocDoNotCheckForUpdates";
 
-        public static bool ShouldCheckForUpdates {
+        public static bool ShouldCheckForUpdates
+        {
             get => !File.Exists(CheckForUpdatesFile);
-            set {
-                if (value) {
+            set
+            {
+                if (value)
+                {
                     if (File.Exists(CheckForUpdatesFile))
                         File.Delete(CheckForUpdatesFile);
-                } else if (!File.Exists(CheckForUpdatesFile))
+                }
+                else if (!File.Exists(CheckForUpdatesFile))
                     File.Create(CheckForUpdatesFile).Dispose();
             }
         }
@@ -24,9 +30,11 @@ namespace Editor.Updater {
 
         private static bool _checkForUpdates = ShouldCheckForUpdates;
 
-        private void OnGUI() {
+        private void OnGUI()
+        {
             var value = EditorGUILayout.Toggle(new GUIContent("Check for updates", "When Unity starts, a request will be made to GitHub if there are sloc updates available.\nIf a new version was released, you can choose to update or stay on the current version."), _checkForUpdates);
-            if (value != _checkForUpdates) {
+            if (value != _checkForUpdates)
+            {
                 _checkForUpdates = value;
                 ShouldCheckForUpdates = value;
             }

--- a/Editor/sloc/ColliderModeEditor.cs
+++ b/Editor/sloc/ColliderModeEditor.cs
@@ -6,11 +6,13 @@ using slocExporter.Objects;
 using UnityEditor;
 using static slocExporter.ColliderModeSetter;
 
-namespace Editor.sloc {
+namespace Editor.sloc
+{
 
     [CustomEditor(typeof(ColliderModeSetter))]
     [CanEditMultipleObjects]
-    public sealed class ColliderModeEditor : UnityEditor.Editor {
+    public sealed class ColliderModeEditor : UnityEditor.Editor
+    {
 
         private static readonly List<string> Options = Enum.GetValues(typeof(PrimitiveObject.ColliderCreationMode))
             .Cast<PrimitiveObject.ColliderCreationMode>()
@@ -18,7 +20,8 @@ namespace Editor.sloc {
 
         private static readonly string[] OptionsArray = Options.ToArray();
 
-        public override void OnInspectorGUI() {
+        public override void OnInspectorGUI()
+        {
             var targetsCache = targets;
             if (targetsCache.Length < 1)
                 return;

--- a/Editor/sloc/ExporterWindow.cs
+++ b/Editor/sloc/ExporterWindow.cs
@@ -34,7 +34,8 @@ namespace Editor.sloc
 
         private static readonly string[] OptionsArray = Enum.GetValues(typeof(PrimitiveObject.ColliderCreationMode))
             .Cast<PrimitiveObject.ColliderCreationMode>()
-            .Select(ModeToString).ToArray();
+            .Select(ModeToString)
+            .ToArray();
 
         private static readonly List<string> Options = new(OptionsArray);
 

--- a/Editor/sloc/ExporterWindow.cs
+++ b/Editor/sloc/ExporterWindow.cs
@@ -18,6 +18,7 @@ namespace Editor.sloc
         private const string ProgressbarTitle = "slocExporter";
         private const string LossyColorDescription = "Uses a single 32-bit integer for colors instead of four 32-bit floats (16 bytes per color). This reduces file size but limits the RGB color range to 0-255 and therefore loses precision.";
         private const string Asterisk = "Hover over an item with an * for more information.";
+        private const string FilePathStateKey = "slocExporterExportFilePath";
 
         [MenuItem("sloc/Export")]
         public static void ShowWindow() => GetWindow<ExporterWindow>(true, "Export to sloc");
@@ -39,6 +40,8 @@ namespace Editor.sloc
 
         private static readonly List<string> Options = new(OptionsArray);
 
+        private void OnEnable() => _filePath = SessionState.GetString(FilePathStateKey, _filePath);
+
         private void OnGUI()
         {
             GUILayout.Label("File", EditorStyles.boldLabel);
@@ -58,6 +61,7 @@ namespace Editor.sloc
             }
 
             _filePath = EditorGUILayout.TextField("Path", filePath);
+            SessionState.SetString(FilePathStateKey, _filePath);
             GUILayout.Space(10);
             GUILayout.Label("Attributes", EditorStyles.boldLabel);
             _lossyColors = EditorGUILayout.Toggle(new GUIContent("Lossy Colors*", LossyColorDescription), _lossyColors);

--- a/Editor/sloc/ExporterWindow.cs
+++ b/Editor/sloc/ExporterWindow.cs
@@ -9,9 +9,11 @@ using UnityEngine;
 using UnityEngine.SceneManagement;
 using static slocExporter.ColliderModeSetter;
 
-namespace Editor.sloc {
+namespace Editor.sloc
+{
 
-    public sealed class ExporterWindow : EditorWindow {
+    public sealed class ExporterWindow : EditorWindow
+    {
 
         private const string ProgressbarTitle = "slocExporter";
         private const string LossyColorDescription = "Uses a single 32-bit integer for colors instead of four 32-bit floats (16 bytes per color). This reduces file size but limits the RGB color range to 0-255 and therefore loses precision.";
@@ -36,10 +38,12 @@ namespace Editor.sloc {
 
         private static readonly List<string> Options = new(OptionsArray);
 
-        private void OnGUI() {
+        private void OnGUI()
+        {
             GUILayout.Label("File", EditorStyles.boldLabel);
             var filePath = _filePath;
-            if (GUILayout.Button("Select File")) {
+            if (GUILayout.Button("Select File"))
+            {
                 var sceneName = SceneManager.GetActiveScene().name;
                 var path = EditorUtility.SaveFilePanel(
                     "Save sloc file", string.IsNullOrEmpty(_filePath) || !Directory.Exists(_filePath.ToFullAppDataPath())
@@ -71,8 +75,10 @@ namespace Editor.sloc {
                 Repaint();
         }
 
-        private static void Export(bool selectedOnly) {
-            if (!ObjectExporter.Init(_debug, _filePath, CreateAttributes(), _collider)) {
+        private static void Export(bool selectedOnly)
+        {
+            if (!ObjectExporter.Init(_debug, _filePath, CreateAttributes(), _collider))
+            {
                 EditorUtility.DisplayDialog(ProgressbarTitle, "Export is already in progress", "OK");
                 return;
             }
@@ -82,7 +88,8 @@ namespace Editor.sloc {
             EditorUtility.ClearProgressBar();
         }
 
-        private static slocAttributes CreateAttributes() {
+        private static slocAttributes CreateAttributes()
+        {
             var attribute = slocAttributes.None;
             if (_lossyColors)
                 attribute |= slocAttributes.LossyColors;

--- a/Editor/sloc/ImporterWindow.cs
+++ b/Editor/sloc/ImporterWindow.cs
@@ -9,6 +9,7 @@ namespace Editor.sloc
     {
 
         private const string ProgressbarTitle = "slocImporter";
+        private const string FilePathStateKey = "slocExporterImportFilePath";
 
         [MenuItem("sloc/Import")]
         public static void ShowWindow() => GetWindow<ImporterWindow>(true, "Import an sloc file");
@@ -19,6 +20,8 @@ namespace Editor.sloc
 
         private static bool _colorsFolderOnly;
 
+        private void OnEnable() => SessionState.GetString(FilePathStateKey, _filePath);
+
         private void OnGUI()
         {
             _useExistingMaterials = EditorGUILayout.Toggle(new GUIContent("Use Existing Materials", "When enabled, the importer tries to use existing materials in the assets."), _useExistingMaterials);
@@ -26,6 +29,7 @@ namespace Editor.sloc
             _filePath = EditorGUILayout.TextField("File Path:", _filePath);
             if (GUILayout.Button("Select File"))
                 _filePath = EditorUtility.OpenFilePanel("Select sloc file to import", _filePath, "sloc").ToShortAppDataPath();
+            SessionState.SetString(FilePathStateKey, _filePath);
             if (!GUILayout.Button("Import Objects"))
                 return;
             if (!slocImporter.Init(_filePath, _useExistingMaterials, _colorsFolderOnly))

--- a/Editor/sloc/ImporterWindow.cs
+++ b/Editor/sloc/ImporterWindow.cs
@@ -2,9 +2,11 @@
 using UnityEditor;
 using UnityEngine;
 
-namespace Editor.sloc {
+namespace Editor.sloc
+{
 
-    public sealed class ImporterWindow : EditorWindow {
+    public sealed class ImporterWindow : EditorWindow
+    {
 
         private const string ProgressbarTitle = "slocImporter";
 
@@ -17,7 +19,8 @@ namespace Editor.sloc {
 
         private static bool _colorsFolderOnly;
 
-        private void OnGUI() {
+        private void OnGUI()
+        {
             _useExistingMaterials = EditorGUILayout.Toggle(new GUIContent("Use Existing Materials", "When enabled, the importer tries to use existing materials in the assets."), _useExistingMaterials);
             _colorsFolderOnly = EditorGUILayout.Toggle(new GUIContent("Search in Colors", "When enabled, only materials in the Assets/Colors folder will be attempted to be used."), _colorsFolderOnly);
             _filePath = EditorGUILayout.TextField("File Path:", _filePath);
@@ -25,7 +28,8 @@ namespace Editor.sloc {
                 _filePath = EditorUtility.OpenFilePanel("Select sloc file to import", _filePath, "sloc").ToShortAppDataPath();
             if (!GUILayout.Button("Import Objects"))
                 return;
-            if (!slocImporter.Init(_filePath, _useExistingMaterials, _colorsFolderOnly)) {
+            if (!slocImporter.Init(_filePath, _useExistingMaterials, _colorsFolderOnly))
+            {
                 EditorUtility.DisplayDialog(ProgressbarTitle, "Import is already in progress", "OK");
                 return;
             }

--- a/Editor/sloc/TriggerActions/ActionRenderers.cs
+++ b/Editor/sloc/TriggerActions/ActionRenderers.cs
@@ -1,8 +1,10 @@
 ﻿using Editor.sloc.TriggerActions.Renderers;
 
-namespace Editor.sloc.TriggerActions {
+namespace Editor.sloc.TriggerActions
+{
 
-    public static class ActionRenderers {
+    public static class ActionRenderers
+    {
 
         public static readonly SimplePositionRenderer TeleportToPosition = new(
             "Absolute Position",

--- a/Editor/sloc/TriggerActions/MainTriggerActionEditor.cs
+++ b/Editor/sloc/TriggerActions/MainTriggerActionEditor.cs
@@ -8,12 +8,15 @@ using slocExporter.TriggerActions.Enums;
 using UnityEditor;
 using UnityEngine;
 
-namespace Editor.sloc.TriggerActions {
+namespace Editor.sloc.TriggerActions
+{
 
     [CustomEditor(typeof(TriggerAction))]
-    public sealed class MainTriggerActionEditor : UnityEditor.Editor {
+    public sealed class MainTriggerActionEditor : UnityEditor.Editor
+    {
 
-        private static readonly Dictionary<TriggerActionType, ITriggerActionEditorRenderer> Renderers = new() {
+        private static readonly Dictionary<TriggerActionType, ITriggerActionEditorRenderer> Renderers = new()
+        {
             {TriggerActionType.TeleportToPosition, ActionRenderers.TeleportToPosition},
             {TriggerActionType.MoveRelativeToSelf, ActionRenderers.MoveRelativeToSelf},
             {TriggerActionType.TeleportToRoom, ActionRenderers.TeleportToRoom},
@@ -28,25 +31,29 @@ namespace Editor.sloc.TriggerActions {
         private static readonly GUIContent TargetsContent = new("Targets", "Types of objects that can trigger this action.");
         private static readonly GUIContent EventsContent = new("Trigger Events", "The trigger event types that this action will listen for.");
 
-        private static readonly Dictionary<TriggerEventType, GUIContent> EventDescriptions = new() {
+        private static readonly Dictionary<TriggerEventType, GUIContent> EventDescriptions = new()
+        {
             {TriggerEventType.Enter, new GUIContent("On Enter", "Invoked when an object enters the trigger.")},
             {TriggerEventType.Stay, new GUIContent("On Stay", "Invoked every frame while an object stays in the trigger.")},
             {TriggerEventType.Exit, new GUIContent("On Exit", "Invoked when an object leaves the trigger.")}
         };
 
-        public override void OnInspectorGUI() {
+        public override void OnInspectorGUI()
+        {
             var triggerAction = (TriggerAction) target;
             var index = Array.IndexOf(Values, triggerAction.type);
             var newIndex = EditorGUILayout.Popup("Action Type", index, Names);
             var newType = Values[newIndex];
-            if (newIndex != index) {
+            if (newIndex != index)
+            {
                 Undo.RecordObject(triggerAction, "Change Trigger Action Type");
                 triggerAction.type = newType;
             }
 
             var data = triggerAction.SelectedData ?? AssignDefaultValue(triggerAction, triggerAction.type);
             var curType = triggerAction.type;
-            if (!Renderers.TryGetValue(curType, out var renderer)) {
+            if (!Renderers.TryGetValue(curType, out var renderer))
+            {
                 EditorGUILayout.HelpBox("You can't edit this type! Please choose another one.", MessageType.Error);
                 TriggerAction.CurrentGizmosDrawer = null;
                 return;
@@ -61,14 +68,16 @@ namespace Editor.sloc.TriggerActions {
             TriggerAction.CurrentGizmosDrawer = renderer is ISelectedGizmosDrawer gizmosDrawer ? gizmosDrawer.DrawGizmos : null;
         }
 
-        private static void DrawCheckboxes(TriggerAction triggerAction, BaseTriggerActionData data) {
+        private static void DrawCheckboxes(TriggerAction triggerAction, BaseTriggerActionData data)
+        {
             if (data == null)
                 return;
             DrawTargetTypeCheckboxes(triggerAction, data);
             DrawEventTypeCheckboxes(triggerAction, data);
         }
 
-        private static void DrawTargetTypeCheckboxes(TriggerAction triggerAction, BaseTriggerActionData data) {
+        private static void DrawTargetTypeCheckboxes(TriggerAction triggerAction, BaseTriggerActionData data)
+        {
             var types = ActionManager.TargetTypeValues.Where(v => v != TargetType.None && data.PossibleTargets.HasFlagFast(v)).ToArray();
             if (types.Length < 1)
                 return;
@@ -77,7 +86,8 @@ namespace Editor.sloc.TriggerActions {
             if (!triggerAction.ToggleTargets)
                 return;
             var value = data.SelectedTargets;
-            foreach (var type in types) {
+            foreach (var type in types)
+            {
                 var active = EditorGUILayout.Toggle(type.ToString(), value.HasFlagFast(type));
                 if (active)
                     value |= type;
@@ -91,13 +101,15 @@ namespace Editor.sloc.TriggerActions {
             data.SelectedTargets = value;
         }
 
-        private static void DrawEventTypeCheckboxes(TriggerAction triggerAction, BaseTriggerActionData data) {
+        private static void DrawEventTypeCheckboxes(TriggerAction triggerAction, BaseTriggerActionData data)
+        {
             EditorGUILayout.Space(5);
             triggerAction.ToggleEvents = EditorGUILayout.Foldout(triggerAction.ToggleEvents, EventsContent, true);
             if (!triggerAction.ToggleEvents)
                 return;
             var value = data.SelectedEvents;
-            foreach (var type in ActionManager.EventTypeValues) {
+            foreach (var type in ActionManager.EventTypeValues)
+            {
                 var content = EventDescriptions.GetValueOrDefault(type) ?? new GUIContent(type.ToString());
                 var active = EditorGUILayout.Toggle(content, value.HasFlagFast(type));
                 if (active)
@@ -112,7 +124,8 @@ namespace Editor.sloc.TriggerActions {
             data.SelectedEvents = value;
         }
 
-        private static BaseTriggerActionData AssignDefaultValue(TriggerAction triggerAction, TriggerActionType type) => type switch {
+        private static BaseTriggerActionData AssignDefaultValue(TriggerAction triggerAction, TriggerActionType type) => type switch
+        {
             TriggerActionType.TeleportToPosition => triggerAction.tpToPos ??= new TeleportToPositionData(Vector3.zero),
             TriggerActionType.TeleportToRoom => triggerAction.tpToRoom ??= new TeleportToRoomData("Unknown", Vector3.zero),
             TriggerActionType.MoveRelativeToSelf => triggerAction.moveRel ??= new MoveRelativeToSelfData(Vector3.zero),

--- a/Editor/sloc/TriggerActions/Renderers/ISelectedGizmosDrawer.cs
+++ b/Editor/sloc/TriggerActions/Renderers/ISelectedGizmosDrawer.cs
@@ -1,8 +1,10 @@
 ﻿using slocExporter.TriggerActions;
 
-namespace Editor.sloc.TriggerActions.Renderers {
+namespace Editor.sloc.TriggerActions.Renderers
+{
 
-    public interface ISelectedGizmosDrawer {
+    public interface ISelectedGizmosDrawer
+    {
 
         void DrawGizmos(TriggerAction instance);
 

--- a/Editor/sloc/TriggerActions/Renderers/ITriggerActionEditorRenderer.cs
+++ b/Editor/sloc/TriggerActions/Renderers/ITriggerActionEditorRenderer.cs
@@ -1,8 +1,10 @@
 ﻿using slocExporter.TriggerActions;
 
-namespace Editor.sloc.TriggerActions.Renderers {
+namespace Editor.sloc.TriggerActions.Renderers
+{
 
-    public interface ITriggerActionEditorRenderer {
+    public interface ITriggerActionEditorRenderer
+    {
 
         string Description { get; }
 

--- a/Editor/sloc/TriggerActions/Renderers/KillPlayerRenderer.cs
+++ b/Editor/sloc/TriggerActions/Renderers/KillPlayerRenderer.cs
@@ -2,13 +2,16 @@
 using UnityEditor;
 using UnityEngine;
 
-namespace Editor.sloc.TriggerActions.Renderers {
+namespace Editor.sloc.TriggerActions.Renderers
+{
 
-    public sealed class KillPlayerRenderer : ITriggerActionEditorRenderer {
+    public sealed class KillPlayerRenderer : ITriggerActionEditorRenderer
+    {
 
         public string Description => "Kills the player with a specified cause.";
 
-        public void DrawGUI(TriggerAction instance) {
+        public void DrawGUI(TriggerAction instance)
+        {
             GUILayout.Label("Death Cause:");
             var i = instance.killPlayer;
             var input = EditorGUILayout.TextArea(i.Cause);

--- a/Editor/sloc/TriggerActions/Renderers/SimplePositionRenderer.cs
+++ b/Editor/sloc/TriggerActions/Renderers/SimplePositionRenderer.cs
@@ -16,8 +16,8 @@ namespace Editor.sloc.TriggerActions.Renderers
         {
             {TeleportOptions.ResetFallDamage, new GUIContent("Reset Fall Damage", "Resets fall damage on the target player.")},
             {TeleportOptions.ResetVelocity, new GUIContent("Reset Velocity", "Resets the target object's velocity. Applies to items and ragdolls only.")},
-            {TeleportOptions.WorldSpaceTransform, new GUIContent("World Space Transform", "Uses world-space transform to calculate the offset instead of relative calculation based on the object this action is added to.")},
-            {TeleportOptions.DeltaRotation, new GUIContent("Delta Rotation", "If enabled, the object will be rotated on the Y axis by the specified amount, ignoring world-space transform.")}
+            {TeleportOptions.WorldSpaceTransform, new GUIContent("World Space Transform", "Uses world-space transform to calculate the offset instead of relative calculation. The result is based on the object reference (e.g. room object associated with a TeleportToRoom action).")},
+            {TeleportOptions.DeltaRotation, new GUIContent("Delta Rotation", "If enabled, the object will be rotated on the Y axis by the specified amount, ignoring world-space transform. When disabled, the object's Y rotation will be set to the transformed value.")}
         };
 
         public delegate BaseTeleportData PositionGetter(TriggerAction instance);

--- a/Editor/sloc/TriggerActions/Renderers/SimplePositionRenderer.cs
+++ b/Editor/sloc/TriggerActions/Renderers/SimplePositionRenderer.cs
@@ -5,11 +5,14 @@ using slocExporter.TriggerActions.Enums;
 using UnityEditor;
 using UnityEngine;
 
-namespace Editor.sloc.TriggerActions.Renderers {
+namespace Editor.sloc.TriggerActions.Renderers
+{
 
-    public sealed class SimplePositionRenderer : ITriggerActionEditorRenderer {
+    public sealed class SimplePositionRenderer : ITriggerActionEditorRenderer
+    {
 
-        private static readonly Dictionary<TeleportOptions, GUIContent> TeleportOptionsContent = new() {
+        private static readonly Dictionary<TeleportOptions, GUIContent> TeleportOptionsContent = new()
+        {
             {TeleportOptions.ResetFallDamage, new GUIContent("Reset Fall Damage", "Resets fall damage on the target player.")},
             {TeleportOptions.ResetVelocity, new GUIContent("Reset Velocity", "Resets the target player's velocity.")},
             {TeleportOptions.WorldSpaceTransform, new GUIContent("World Space Transform", "Uses world-space transform to calculate the offset instead of relative calculation based on the object this action is added to.")}
@@ -22,16 +25,19 @@ namespace Editor.sloc.TriggerActions.Renderers {
         private readonly string _label;
         private readonly PositionGetter _positionGetter;
 
-        public SimplePositionRenderer(string label, PositionGetter positionGetter, string description) {
+        public SimplePositionRenderer(string label, PositionGetter positionGetter, string description)
+        {
             _label = label;
             _positionGetter = positionGetter;
             Description = description;
         }
 
-        public void DrawGUI(TriggerAction instance) {
+        public void DrawGUI(TriggerAction instance)
+        {
             var i = _positionGetter(instance);
             var input = EditorGUILayout.Vector3Field(_label, i.Position);
-            if (input != i.Position) {
+            if (input != i.Position)
+            {
                 Undo.RecordObject(instance, "Change Teleport Offset");
                 i.Position = input;
             }
@@ -39,9 +45,11 @@ namespace Editor.sloc.TriggerActions.Renderers {
             DrawCheckboxes(instance, i);
         }
 
-        public static void DrawCheckboxes(TriggerAction triggerAction, BaseTeleportData data) {
+        public static void DrawCheckboxes(TriggerAction triggerAction, BaseTeleportData data)
+        {
             var value = data.Options;
-            foreach (var type in ActionManager.TeleportOptionsValues) {
+            foreach (var type in ActionManager.TeleportOptionsValues)
+            {
                 var content = TeleportOptionsContent.GetValueOrDefault(type) ?? new GUIContent(type.ToString());
                 var active = EditorGUILayout.Toggle(content, value.HasFlagFast(type));
                 if (active)

--- a/Editor/sloc/TriggerActions/Renderers/TeleportToRoomRenderer.cs
+++ b/Editor/sloc/TriggerActions/Renderers/TeleportToRoomRenderer.cs
@@ -1,22 +1,27 @@
 ﻿using slocExporter.TriggerActions;
 using UnityEditor;
 
-namespace Editor.sloc.TriggerActions.Renderers {
+namespace Editor.sloc.TriggerActions.Renderers
+{
 
-    public sealed class TeleportToRoomRenderer : ITriggerActionEditorRenderer {
+    public sealed class TeleportToRoomRenderer : ITriggerActionEditorRenderer
+    {
 
         public string Description => "Teleports the object to a specified room with the given position offset.";
 
-        public void DrawGUI(TriggerAction instance) {
+        public void DrawGUI(TriggerAction instance)
+        {
             var data = instance.tpToRoom;
             var room = EditorGUILayout.TextField("Room Name", data.Room);
-            if (room != data.Room) {
+            if (room != data.Room)
+            {
                 Undo.RecordObject(instance, "Change Teleport Room");
                 data.Room = room;
             }
 
             var position = EditorGUILayout.Vector3Field("Position Offset", data.Position);
-            if (position != data.Position) {
+            if (position != data.Position)
+            {
                 Undo.RecordObject(instance, "Change Teleport Offset");
                 data.Position = position;
             }

--- a/Editor/sloc/TriggerActions/Renderers/TeleportToRoomRenderer.cs
+++ b/Editor/sloc/TriggerActions/Renderers/TeleportToRoomRenderer.cs
@@ -1,5 +1,6 @@
 ﻿using slocExporter.TriggerActions;
 using UnityEditor;
+using UnityEngine;
 
 namespace Editor.sloc.TriggerActions.Renderers
 {
@@ -19,6 +20,8 @@ namespace Editor.sloc.TriggerActions.Renderers
                 data.Room = room;
             }
 
+            if (EditorGUILayout.LinkButton("Room names (see attribute values)"))
+                Application.OpenURL("https://github.com/Axwabo/SCPSL-Helpers/blob/main/Axwabo.Helpers.NWAPI/Config/RoomType.cs");
             SimplePositionRenderer.DrawCommonElements(instance, data);
         }
 

--- a/Editor/sloc/TriggerActions/Renderers/TeleportToRoomRenderer.cs
+++ b/Editor/sloc/TriggerActions/Renderers/TeleportToRoomRenderer.cs
@@ -19,14 +19,7 @@ namespace Editor.sloc.TriggerActions.Renderers
                 data.Room = room;
             }
 
-            var position = EditorGUILayout.Vector3Field("Position Offset", data.Position);
-            if (position != data.Position)
-            {
-                Undo.RecordObject(instance, "Change Teleport Offset");
-                data.Position = position;
-            }
-
-            SimplePositionRenderer.DrawCheckboxes(instance, data);
+            SimplePositionRenderer.DrawCommonElements(instance, data);
         }
 
     }

--- a/Editor/sloc/TriggerActions/Renderers/TeleportToSpawnedObjectRenderer.cs
+++ b/Editor/sloc/TriggerActions/Renderers/TeleportToSpawnedObjectRenderer.cs
@@ -24,15 +24,7 @@ namespace Editor.sloc.TriggerActions.Renderers
                 data.Target = go;
             }
 
-            var input = EditorGUILayout.Vector3Field("Offset", data.Position);
-            if (input != data.Position)
-            {
-                EditorUtility.SetDirty(instance);
-                Undo.RecordObject(instance, "Change Teleport Offset");
-                data.Position = input;
-            }
-
-            SimplePositionRenderer.DrawCheckboxes(instance, data);
+            SimplePositionRenderer.DrawCommonElements(instance, data);
             if (IsValidObject(go))
                 EditorGUILayout.HelpBox("A green wire sphere gizmo is indicating the point to teleport to", MessageType.Info);
             else

--- a/Editor/sloc/TriggerActions/Renderers/TeleportToSpawnedObjectRenderer.cs
+++ b/Editor/sloc/TriggerActions/Renderers/TeleportToSpawnedObjectRenderer.cs
@@ -3,25 +3,30 @@ using slocExporter.TriggerActions;
 using UnityEditor;
 using UnityEngine;
 
-namespace Editor.sloc.TriggerActions.Renderers {
+namespace Editor.sloc.TriggerActions.Renderers
+{
 
-    public sealed class TeleportToSpawnedObjectRenderer : ITriggerActionEditorRenderer, ISelectedGizmosDrawer {
+    public sealed class TeleportToSpawnedObjectRenderer : ITriggerActionEditorRenderer, ISelectedGizmosDrawer
+    {
 
         private static readonly GUIContent Content = new("Target Object", "The object to teleport to.");
 
         public string Description => "Teleports the object to another specified object with the given position offset.";
 
-        public void DrawGUI(TriggerAction instance) {
+        public void DrawGUI(TriggerAction instance)
+        {
             var data = instance.tpToSpawnedObject;
             var go = EditorGUILayout.ObjectField(Content, data.Target, typeof(GameObject), true) as GameObject;
-            if (data.Target != go) {
+            if (data.Target != go)
+            {
                 EditorUtility.SetDirty(instance);
                 Undo.RecordObject(instance, "Change Teleport Target");
                 data.Target = go;
             }
 
             var input = EditorGUILayout.Vector3Field("Offset", data.Position);
-            if (input != data.Position) {
+            if (input != data.Position)
+            {
                 EditorUtility.SetDirty(instance);
                 Undo.RecordObject(instance, "Change Teleport Offset");
                 data.Position = input;
@@ -34,7 +39,8 @@ namespace Editor.sloc.TriggerActions.Renderers {
                 EditorGUILayout.HelpBox("Target must be a spawnable primitive (with a light or valid mesh)", MessageType.Error);
         }
 
-        public void DrawGizmos(TriggerAction instance) {
+        public void DrawGizmos(TriggerAction instance)
+        {
             var data = instance.tpToSpawnedObject;
             var go = data?.Target;
             if (!go)

--- a/Editor/sloc/TriggerActions/Renderers/TeleporterImmunityRenderer.cs
+++ b/Editor/sloc/TriggerActions/Renderers/TeleporterImmunityRenderer.cs
@@ -1,16 +1,20 @@
-﻿using slocExporter.TriggerActions;
+﻿using System;
+using slocExporter.TriggerActions;
 using slocExporter.TriggerActions.Data;
 using slocExporter.TriggerActions.Enums;
 using UnityEditor;
 using UnityEngine;
 
-namespace Editor.sloc.TriggerActions.Renderers {
+namespace Editor.sloc.TriggerActions.Renderers
+{
 
-    public sealed class TeleporterImmunityRenderer : ITriggerActionEditorRenderer {
+    public sealed class TeleporterImmunityRenderer : ITriggerActionEditorRenderer
+    {
 
         private static readonly GUIContent DurationLabel = new("Duration Mode");
 
-        private static readonly GUIContent[] DurationContent = {
+        private static readonly GUIContent[] DurationContent =
+        {
             new("Absolute", "The current duration will be overwritten with the specified amount of time."),
             new("Add", "The given time is added to the current immunity time."),
             new("Subtract", "The given time is subtracted from the current immunity time.")
@@ -18,22 +22,25 @@ namespace Editor.sloc.TriggerActions.Renderers {
 
         public string Description => "Makes the player immune to teleporters for a specified amount of time.\nIf set to global, they will be immune to all teleporters; otherwise just the one that triggered this action.";
 
-        public void DrawGUI(TriggerAction instance) {
+        public void DrawGUI(TriggerAction instance)
+        {
             var data = instance.tpImmunity;
             var global = EditorGUILayout.Toggle("Is Global", data.IsGlobal);
-            if (global != data.IsGlobal) {
+            if (global != data.IsGlobal)
+            {
                 Undo.RecordObject(instance, "Change Immunity Global Mode");
                 data.IsGlobal = global;
             }
 
             var mode = (ImmunityDurationMode) EditorGUILayout.Popup(DurationLabel, (int) data.DurationMode, DurationContent);
-            if (mode != data.DurationMode) {
+            if (mode != data.DurationMode)
+            {
                 Undo.RecordObject(instance, "Change Immunity Duration Mode");
                 data.DurationMode = mode;
             }
 
             var duration = EditorGUILayout.Slider("Duration (seconds)", data.Duration, 0, TeleporterImmunityData.MaxValue);
-            if (duration == data.Duration)
+            if (Math.Abs(duration - data.Duration) < 0.001f)
                 return;
             Undo.RecordObject(instance, "Change Immunity Duration Time");
             data.Duration = duration;

--- a/Editor/sloc/TriggerActions/TriggerActionEditorRenderer.cs
+++ b/Editor/sloc/TriggerActions/TriggerActionEditorRenderer.cs
@@ -1,6 +1,7 @@
 ﻿using slocExporter.TriggerActions;
 
-namespace Editor.sloc.TriggerActions {
+namespace Editor.sloc.TriggerActions
+{
 
     public delegate void TriggerActionEditorRenderer(TriggerAction instance);
 

--- a/Scripts/InstanceDictionary.cs
+++ b/Scripts/InstanceDictionary.cs
@@ -1,11 +1,14 @@
 ﻿using System.Collections.Generic;
 
-public sealed class InstanceDictionary<T> : Dictionary<int, T> {
+public sealed class InstanceDictionary<T> : Dictionary<int, T>
+{
 
     public T GetOrReturn(int id, T value, bool extraCondition = true) => extraCondition && TryGetValue(id, out var existing) ? existing : value;
 
-    public bool TryGet<TGet>(int id, out TGet value) {
-        if (TryGetValue(id, out var obj) && obj is TGet t) {
+    public bool TryGet<TGet>(int id, out TGet value)
+    {
+        if (TryGetValue(id, out var obj) && obj is TGet t)
+        {
             value = t;
             return true;
         }

--- a/Scripts/InstanceList.cs
+++ b/Scripts/InstanceList.cs
@@ -1,12 +1,15 @@
 ﻿using System.Collections.Generic;
 using slocExporter.Objects;
 
-public sealed class InstanceList : List<KeyValuePair<int, slocGameObject>> {
+public sealed class InstanceList : List<KeyValuePair<int, slocGameObject>>
+{
 
-    public InstanceList(IEnumerable<KeyValuePair<int, slocGameObject>> collection) : base(collection) {
+    public InstanceList(IEnumerable<KeyValuePair<int, slocGameObject>> collection) : base(collection)
+    {
     }
 
-    public bool TryGet<T>(int index, out int id, out T item) where T : slocGameObject {
+    public bool TryGet<T>(int index, out int id, out T item) where T : slocGameObject
+    {
         var pair = this[index];
         id = pair.Key;
         item = pair.Value as T;

--- a/Scripts/ObjectExporter.cs
+++ b/Scripts/ObjectExporter.cs
@@ -50,13 +50,13 @@ public static class ObjectExporter
         {"da8fd4315d23e984fa861e05c4e0f3cc", StructureObject.StructureType.MiscellaneousLocker},
         {"581e190a7fcffe14b8ed1f3b72d4719d", StructureObject.StructureType.RifleRack},
         {"4a1fa0d57462cb34db76e55e9de544fc", StructureObject.StructureType.Scp018Pedestal},
+        {"cb1f8708ad190734ba785b3cdafafb66", StructureObject.StructureType.Scp207Pedestal},
+        {"c960034df4c76fe4f8a3cd08a58d883c", StructureObject.StructureType.Scp244Pedestal},
+        {"17a2b65d1966ef041aac04e61ec852f6", StructureObject.StructureType.Scp268Pedestal},
+        {"d38194e63b3da2b4a80979c17f887d0b", StructureObject.StructureType.Scp500Pedestal},
         {"41460fe253b9dd2438beb331ddc0ca25", StructureObject.StructureType.Scp1576Pedestal},
         {"8e1c86dc26ed42e4eb519aedd0e9fcd1", StructureObject.StructureType.Scp1853Pedestal},
         {"6ad060242329d2d46ab64c47fd417146", StructureObject.StructureType.Scp2176Pedestal},
-        {"c960034df4c76fe4f8a3cd08a58d883c", StructureObject.StructureType.Scp244Pedestal},
-        {"cb1f8708ad190734ba785b3cdafafb66", StructureObject.StructureType.Scp244Pedestal},
-        {"17a2b65d1966ef041aac04e61ec852f6", StructureObject.StructureType.Scp268Pedestal},
-        {"d38194e63b3da2b4a80979c17f887d0b", StructureObject.StructureType.Scp500Pedestal},
         {"b39d8037aa87d5348af5c3ad54251890", StructureObject.StructureType.SportTarget},
         {"67777259bd9055040bc1be50789f9624", StructureObject.StructureType.Workstation}
     };

--- a/Scripts/ObjectExporter.cs
+++ b/Scripts/ObjectExporter.cs
@@ -36,6 +36,31 @@ public static class ObjectExporter
 
     public static ObjectType FindObjectType(string meshName) => PrimitiveTypes.FirstOrDefault(e => e.Key.IsMatch(meshName)).Value;
 
+    public static readonly Dictionary<string, StructureObject.StructureType> StructureGuids = new()
+    {
+        {"c9027d87e276243499d0855914516728", StructureObject.StructureType.Adrenaline},
+        {"c89913dc758501e4d88bbd018f72c543", StructureObject.StructureType.BinaryTarget},
+        {"db20325cd26c8c84eb3ad5b333807b21", StructureObject.StructureType.DboyTarget},
+        {"1b1ee647e05e4bf4491ce470b3982de3", StructureObject.StructureType.EzBreakableDoor},
+        {"cecdb86e000e08445895728aa8890bfb", StructureObject.StructureType.Generator},
+        {"1a97804ccde6c3f4f835c0dcd09c6f85", StructureObject.StructureType.HczBreakableDoor},
+        {"99d103e1d107c434283bcf72ae8b3c76", StructureObject.StructureType.LargeGunLocker},
+        {"bbb9c95a6d1307d4e9c1218f4532072b", StructureObject.StructureType.LczBreakableDoor},
+        {"54c07ebe424ee83429e95a25a10534c6", StructureObject.StructureType.Medkit},
+        {"da8fd4315d23e984fa861e05c4e0f3cc", StructureObject.StructureType.MiscellaneousLocker},
+        {"581e190a7fcffe14b8ed1f3b72d4719d", StructureObject.StructureType.RifleRack},
+        {"4a1fa0d57462cb34db76e55e9de544fc", StructureObject.StructureType.Scp018Pedestal},
+        {"41460fe253b9dd2438beb331ddc0ca25", StructureObject.StructureType.Scp1576Pedestal},
+        {"8e1c86dc26ed42e4eb519aedd0e9fcd1", StructureObject.StructureType.Scp1853Pedestal},
+        {"6ad060242329d2d46ab64c47fd417146", StructureObject.StructureType.Scp2176Pedestal},
+        {"c960034df4c76fe4f8a3cd08a58d883c", StructureObject.StructureType.Scp244Pedestal},
+        {"cb1f8708ad190734ba785b3cdafafb66", StructureObject.StructureType.Scp244Pedestal},
+        {"17a2b65d1966ef041aac04e61ec852f6", StructureObject.StructureType.Scp268Pedestal},
+        {"d38194e63b3da2b4a80979c17f887d0b", StructureObject.StructureType.Scp500Pedestal},
+        {"b39d8037aa87d5348af5c3ad54251890", StructureObject.StructureType.SportTarget},
+        {"67777259bd9055040bc1be50789f9624", StructureObject.StructureType.Workstation}
+    };
+
     #endregion
 
     #region Settings
@@ -125,26 +150,8 @@ public static class ObjectExporter
                 continue;
             }
 
-            foreach (var component in o.GetComponents<Component>())
-            {
-                var skip = component switch
-                {
-                    ExporterIgnored => IgnoreObject(o, objectsById),
-                    Collider collider => ProcessCollider(defaultMode, o, collider, colliders),
-                    ColliderModeSetter setter => SetMode(o, setter, colliders),
-                    TriggerAction triggerAction => AddTriggerAction(o, triggerAction, runtimeTriggerActions),
-                    MeshFilter meshFilter => ProcessMeshFilter(o, meshFilter, objectsById),
-                    MeshRenderer meshRenderer => ProcessRenderer(o, meshRenderer, renderers),
-                    Light light => ProcessLight(o, light, objectsById),
-                    _ => false
-                };
-                if (!skip)
-                    continue;
-                Log($"Skipped object {o.name}");
-                break;
-            }
-
-            CheckIfEmpty(o, objectsById);
+            if (!ProcessGameObject(o, objectsById, defaultMode, colliders, runtimeTriggerActions, renderers))
+                CheckIfEmpty(o, objectsById);
             updateProgress?.Invoke(progressString, progressValue);
         }
 
@@ -159,6 +166,54 @@ public static class ObjectExporter
         WriteObjects(file, nonEmpty, attributes, defaultMode, updateProgress);
         LogWarning($"[slocExporter] Export done in {stopwatch.ElapsedMilliseconds}ms; {nonEmpty.Count} objects exported to {file.ToShortAppDataPath()}");
         exportedCount = nonEmpty.Count;
+    }
+
+    private static bool ProcessGameObject(GameObject o, InstanceDictionary<slocGameObject> objectsById, PrimitiveObject.ColliderCreationMode defaultMode, InstanceDictionary<PrimitiveObject.ColliderCreationMode> colliders, InstanceDictionary<List<BaseTriggerActionData>> runtimeTriggerActions, InstanceDictionary<MeshRenderer> renderers)
+    {
+        if (PrefabUtility.IsPartOfAnyPrefab(o))
+        {
+            ProcessPrefab(o, objectsById);
+            return true;
+        }
+
+        foreach (var component in o.GetComponents<Component>())
+        {
+            var skip = component switch
+            {
+                Collider collider => ProcessCollider(defaultMode, o, collider, colliders),
+                ColliderModeSetter setter => SetMode(o, setter, colliders),
+                TriggerAction triggerAction => AddTriggerAction(o, triggerAction, runtimeTriggerActions),
+                MeshFilter meshFilter => ProcessMeshFilter(o, meshFilter, objectsById),
+                MeshRenderer meshRenderer => ProcessRenderer(o, meshRenderer, renderers),
+                Light light => ProcessLight(o, light, objectsById),
+                _ => false
+            };
+            if (!skip)
+                continue;
+            Log($"Skipped object {o.name}");
+            break;
+        }
+
+        return false;
+    }
+
+    private static void ProcessPrefab(GameObject gameObject, InstanceDictionary<slocGameObject> objectsById)
+    {
+        if (!PrefabUtility.IsOutermostPrefabInstanceRoot(gameObject))
+            return;
+        var prefab = PrefabUtility.GetCorrespondingObjectFromSource(gameObject);
+        if (prefab == null)
+            return;
+        var guid = AssetDatabase.GUIDFromAssetPath(AssetDatabase.GetAssetPath(prefab)).ToString();
+        if (!StructureGuids.TryGetValue(guid, out var type))
+            return;
+        var id = gameObject.GetInstanceID();
+        var parent = gameObject.transform.parent;
+        objectsById[id] = new StructureObject(id, type)
+        {
+            ParentId = parent == null ? id : parent.gameObject.GetInstanceID(),
+            Transform = gameObject.transform
+        };
     }
 
     private static void EnsureDirectoryExists(string file)
@@ -244,13 +299,6 @@ public static class ObjectExporter
     {
         var root = gameObject.transform.root.gameObject;
         return gameObject.tag is ExporterIgnoredTag || gameObject.TryGetComponent(out ExporterIgnored _) || root.tag is RoomTag || root.tag is ExporterIgnoredTag || root.TryGetComponent(out ExporterIgnored _);
-    }
-
-    private static bool IgnoreObject(GameObject gameObject, InstanceDictionary<slocGameObject> objectsById)
-    {
-        Log($"{gameObject.name} is flagged as ExporterIgnored");
-        objectsById.Remove(gameObject.GetInstanceID());
-        return true;
     }
 
     #endregion

--- a/Scripts/slocExporter/API.cs
+++ b/Scripts/slocExporter/API.cs
@@ -19,7 +19,7 @@ namespace slocExporter
 
         public const float ColorDivisionMultiplier = 1f / 255f;
 
-        public const ushort slocVersion = 4;
+        public const ushort slocVersion = 5;
 
         public static string CurrentVersion = "4.0.1";
 
@@ -32,7 +32,8 @@ namespace slocExporter
             {1, new Ver1Reader()},
             {2, new Ver2Reader()},
             {3, new Ver3Reader()},
-            {4, new Ver4Reader()}
+            {4, new Ver4Reader()},
+            {5, new Ver5Reader()}
         };
 
         public static bool TryGetReader(ushort version, out IObjectReader reader) => VersionReaders.TryGetValue(version, out reader);

--- a/Scripts/slocExporter/API.cs
+++ b/Scripts/slocExporter/API.cs
@@ -134,6 +134,8 @@ namespace slocExporter
             var gameObject = (GameObject) PrefabUtility.InstantiatePrefab(prefab);
             gameObject.SetAbsoluteTransformFrom(parent);
             gameObject.SetLocalTransform(structure.Transform);
+            if (structure.RemoveDefaultLoot)
+                gameObject.AddComponent<StructureOverride>().removeDefaultLoot = true;
             return gameObject;
         }
 

--- a/Scripts/slocExporter/API.cs
+++ b/Scripts/slocExporter/API.cs
@@ -21,11 +21,11 @@ namespace slocExporter
 
         public const ushort slocVersion = 5;
 
-        public static string CurrentVersion = "4.0.1";
+        public static string CurrentVersion = "5.0.0";
 
         #region Reader Declarations
 
-        public static readonly IObjectReader DefaultReader = new Ver4Reader();
+        public static readonly IObjectReader DefaultReader = new Ver5Reader();
 
         private static readonly Dictionary<ushort, IObjectReader> VersionReaders = new()
         {

--- a/Scripts/slocExporter/API.cs
+++ b/Scripts/slocExporter/API.cs
@@ -21,7 +21,7 @@ namespace slocExporter
 
         public const ushort slocVersion = 4;
 
-        public static readonly string CurrentVersion = "4.0.1";
+        public static string CurrentVersion = "4.0.1";
 
         #region Reader Declarations
 

--- a/Scripts/slocExporter/API.cs
+++ b/Scripts/slocExporter/API.cs
@@ -8,6 +8,7 @@ using slocExporter.Readers;
 using slocExporter.TriggerActions;
 using slocExporter.TriggerActions.Data;
 using slocExporter.TriggerActions.Enums;
+using UnityEditor;
 using UnityEngine;
 using static slocExporter.MaterialHandler;
 
@@ -91,11 +92,50 @@ namespace slocExporter
 
         public static GameObject CreateObject(this slocGameObject obj, GameObject parent = null, bool throwOnError = true) => obj switch
         {
+            StructureObject structure => CreateStructure(parent, structure),
             PrimitiveObject primitive => CreatePrimitive(parent, primitive),
             LightObject light => CreateLight(parent, light),
             EmptyObject => CreateEmpty(obj, parent),
             _ => throwOnError ? throw new ArgumentOutOfRangeException(nameof(obj.Type), obj.Type, "Unknown object type") : null
         };
+
+        public static readonly Dictionary<StructureObject.StructureType, string> StructureGuids = new()
+        {
+            {StructureObject.StructureType.Adrenaline, "c9027d87e276243499d0855914516728"},
+            {StructureObject.StructureType.BinaryTarget, "c89913dc758501e4d88bbd018f72c543"},
+            {StructureObject.StructureType.DboyTarget, "db20325cd26c8c84eb3ad5b333807b21"},
+            {StructureObject.StructureType.EzBreakableDoor, "1b1ee647e05e4bf4491ce470b3982de3"},
+            {StructureObject.StructureType.Generator, "cecdb86e000e08445895728aa8890bfb"},
+            {StructureObject.StructureType.HczBreakableDoor, "1a97804ccde6c3f4f835c0dcd09c6f85"},
+            {StructureObject.StructureType.LargeGunLocker, "99d103e1d107c434283bcf72ae8b3c76"},
+            {StructureObject.StructureType.LczBreakableDoor, "bbb9c95a6d1307d4e9c1218f4532072b"},
+            {StructureObject.StructureType.Medkit, "54c07ebe424ee83429e95a25a10534c6"},
+            {StructureObject.StructureType.MiscellaneousLocker, "da8fd4315d23e984fa861e05c4e0f3cc"},
+            {StructureObject.StructureType.RifleRack, "581e190a7fcffe14b8ed1f3b72d4719d"},
+            {StructureObject.StructureType.Scp018Pedestal, "4a1fa0d57462cb34db76e55e9de544fc"},
+            {StructureObject.StructureType.Scp207Pedestal, "cb1f8708ad190734ba785b3cdafafb66"},
+            {StructureObject.StructureType.Scp244Pedestal, "c960034df4c76fe4f8a3cd08a58d883c"},
+            {StructureObject.StructureType.Scp268Pedestal, "17a2b65d1966ef041aac04e61ec852f6"},
+            {StructureObject.StructureType.Scp500Pedestal, "d38194e63b3da2b4a80979c17f887d0b"},
+            {StructureObject.StructureType.Scp1576Pedestal, "41460fe253b9dd2438beb331ddc0ca25"},
+            {StructureObject.StructureType.Scp1853Pedestal, "8e1c86dc26ed42e4eb519aedd0e9fcd1"},
+            {StructureObject.StructureType.Scp2176Pedestal, "6ad060242329d2d46ab64c47fd417146"},
+            {StructureObject.StructureType.SportTarget, "b39d8037aa87d5348af5c3ad54251890"},
+            {StructureObject.StructureType.Workstation, "67777259bd9055040bc1be50789f9624"}
+        };
+
+        private static GameObject CreateStructure(GameObject parent, StructureObject structure)
+        {
+            if (!StructureGuids.TryGetValue(structure.Structure, out var guidString) || !GUID.TryParse(guidString, out var guid))
+                return null;
+            var prefab = AssetDatabase.LoadAssetAtPath<GameObject>(AssetDatabase.GUIDToAssetPath(guid));
+            if (prefab == null)
+                return null;
+            var gameObject = (GameObject) PrefabUtility.InstantiatePrefab(prefab);
+            gameObject.SetAbsoluteTransformFrom(parent);
+            gameObject.SetLocalTransform(structure.Transform);
+            return gameObject;
+        }
 
         private static GameObject CreatePrimitive(GameObject parent, PrimitiveObject primitive)
         {

--- a/Scripts/slocExporter/ColliderModeSetter.cs
+++ b/Scripts/slocExporter/ColliderModeSetter.cs
@@ -1,10 +1,12 @@
 ﻿using slocExporter.Objects;
 using UnityEngine;
 
-namespace slocExporter {
+namespace slocExporter
+{
 
     [DisallowMultipleComponent]
-    public sealed class ColliderModeSetter : MonoBehaviour {
+    public sealed class ColliderModeSetter : MonoBehaviour
+    {
 
         private const string NoCollider = "No Collider";
         private const string ClientOnly = "Client-Only";
@@ -15,7 +17,6 @@ namespace slocExporter {
         private const string ServerOnlyNonSpawnedObject = "Server-Only Non-Spawned Object";
         private const string NoColliderNonSpawnedObject = "Colliderless Non-Spawned Object";
 
-        // ReSharper disable InconsistentNaming
         private const string DescriptionNoCollider = "The object will neither have a collider on the client nor on the server.";
         private const string DescriptionClientOnly = "The object will have a collider on the client but not on the server.";
         private const string DescriptionServerOnly = "The object will be spawned on the client.\nIt will only have a collider on the server.";
@@ -29,7 +30,8 @@ namespace slocExporter {
 
         public PrimitiveObject.ColliderCreationMode mode = PrimitiveObject.ColliderCreationMode.Unset;
 
-        public static string ModeToString(PrimitiveObject.ColliderCreationMode mode) => mode switch {
+        public static string ModeToString(PrimitiveObject.ColliderCreationMode mode) => mode switch
+        {
             PrimitiveObject.ColliderCreationMode.NoCollider => NoCollider,
             PrimitiveObject.ColliderCreationMode.ClientOnly => ClientOnly,
             PrimitiveObject.ColliderCreationMode.ServerOnly => ServerOnly,
@@ -41,7 +43,8 @@ namespace slocExporter {
             _ => "Unset"
         };
 
-        public static PrimitiveObject.ColliderCreationMode StringToMode(string mode) => mode switch {
+        public static PrimitiveObject.ColliderCreationMode StringToMode(string mode) => mode switch
+        {
             NoCollider => PrimitiveObject.ColliderCreationMode.NoCollider,
             ClientOnly => PrimitiveObject.ColliderCreationMode.ClientOnly,
             ServerOnly => PrimitiveObject.ColliderCreationMode.ServerOnly,
@@ -53,7 +56,8 @@ namespace slocExporter {
             _ => PrimitiveObject.ColliderCreationMode.Unset
         };
 
-        public static string GetModeDescription(PrimitiveObject.ColliderCreationMode mode, bool isHeader = false) => mode switch {
+        public static string GetModeDescription(PrimitiveObject.ColliderCreationMode mode, bool isHeader = false) => mode switch
+        {
             PrimitiveObject.ColliderCreationMode.NoCollider => DescriptionNoCollider,
             PrimitiveObject.ColliderCreationMode.ClientOnly => DescriptionClientOnly,
             PrimitiveObject.ColliderCreationMode.ServerOnly => DescriptionServerOnly,

--- a/Scripts/slocExporter/ExporterIgnored.cs
+++ b/Scripts/slocExporter/ExporterIgnored.cs
@@ -1,9 +1,11 @@
 ﻿using UnityEngine;
 
-namespace slocExporter {
+namespace slocExporter
+{
 
     [DisallowMultipleComponent]
-    public sealed class ExporterIgnored : MonoBehaviour {
+    public sealed class ExporterIgnored : MonoBehaviour
+    {
 
     }
 

--- a/Scripts/slocExporter/Objects/EmptyObject.cs
+++ b/Scripts/slocExporter/Objects/EmptyObject.cs
@@ -1,8 +1,11 @@
-﻿namespace slocExporter.Objects {
+﻿namespace slocExporter.Objects
+{
 
-    public sealed class EmptyObject : slocGameObject {
+    public sealed class EmptyObject : slocGameObject
+    {
 
-        public EmptyObject() : this(0) {
+        public EmptyObject() : this(0)
+        {
         }
 
         public EmptyObject(int instanceId) : base(instanceId) => Type = ObjectType.Empty;

--- a/Scripts/slocExporter/Objects/LightObject.cs
+++ b/Scripts/slocExporter/Objects/LightObject.cs
@@ -2,11 +2,14 @@
 using slocExporter.Readers;
 using UnityEngine;
 
-namespace slocExporter.Objects {
+namespace slocExporter.Objects
+{
 
-    public sealed class LightObject : slocGameObject {
+    public sealed class LightObject : slocGameObject
+    {
 
-        public LightObject() : this(0) {
+        public LightObject() : this(0)
+        {
         }
 
         public LightObject(int instanceId) : base(instanceId) => Type = ObjectType.Light;
@@ -19,7 +22,8 @@ namespace slocExporter.Objects {
 
         public float Intensity = 1;
 
-        protected override void WriteData(BinaryWriter writer, slocHeader header) {
+        protected override void WriteData(BinaryWriter writer, slocHeader header)
+        {
             if (header.HasAttribute(slocAttributes.LossyColors))
                 writer.Write(LightColor.ToLossyColor());
             else

--- a/Scripts/slocExporter/Objects/ObjectType.cs
+++ b/Scripts/slocExporter/Objects/ObjectType.cs
@@ -1,6 +1,8 @@
-﻿namespace slocExporter.Objects {
+﻿namespace slocExporter.Objects
+{
 
-    public enum ObjectType : byte {
+    public enum ObjectType : byte
+    {
 
         None = 0,
         Light = 1,

--- a/Scripts/slocExporter/Objects/ObjectType.cs
+++ b/Scripts/slocExporter/Objects/ObjectType.cs
@@ -12,7 +12,8 @@
         Cylinder = 5,
         Plane = 6,
         Quad = 7,
-        Empty = 8
+        Empty = 8,
+        Structure = 9
 
     }
 

--- a/Scripts/slocExporter/Objects/PrimitiveObject.cs
+++ b/Scripts/slocExporter/Objects/PrimitiveObject.cs
@@ -5,14 +5,18 @@ using slocExporter.TriggerActions;
 using slocExporter.TriggerActions.Data;
 using UnityEngine;
 
-namespace slocExporter.Objects {
+namespace slocExporter.Objects
+{
 
-    public sealed class PrimitiveObject : slocGameObject {
+    public sealed class PrimitiveObject : slocGameObject
+    {
 
-        public PrimitiveObject(ObjectType type) : this(0, type) {
+        public PrimitiveObject(ObjectType type) : this(0, type)
+        {
         }
 
-        public PrimitiveObject(int instanceId, ObjectType type) : base(instanceId) {
+        public PrimitiveObject(int instanceId, ObjectType type) : base(instanceId)
+        {
             if (type is ObjectType.None or ObjectType.Light)
                 throw new ArgumentException("Invalid primitive type", nameof(type));
             Type = type;
@@ -26,7 +30,8 @@ namespace slocExporter.Objects {
 
         public ColliderCreationMode GetNonUnsetColliderMode() => ColliderMode is ColliderCreationMode.Unset ? ColliderCreationMode.Both : ColliderMode;
 
-        protected override void WriteData(BinaryWriter writer, slocHeader header) {
+        protected override void WriteData(BinaryWriter writer, slocHeader header)
+        {
             if (header.HasAttribute(slocAttributes.LossyColors))
                 writer.Write(MaterialColor.ToLossyColor());
             else
@@ -37,7 +42,8 @@ namespace slocExporter.Objects {
                 ActionManager.WriteActions(writer, TriggerActions);
         }
 
-        public enum ColliderCreationMode : byte {
+        public enum ColliderCreationMode : byte
+        {
 
             Unset = 0,
             NoCollider = 1,

--- a/Scripts/slocExporter/Objects/StructureObject.cs
+++ b/Scripts/slocExporter/Objects/StructureObject.cs
@@ -1,0 +1,56 @@
+﻿using System.IO;
+using slocExporter.Readers;
+
+namespace slocExporter.Objects
+{
+
+    public sealed class StructureObject : slocGameObject
+    {
+
+        public StructureObject(StructureType structureType) : this(0, structureType)
+        {
+        }
+
+        public StructureObject(int instanceId, StructureType structureType) : base(instanceId)
+        {
+            Type = ObjectType.Structure;
+            Structure = structureType;
+        }
+
+        public StructureType Structure { get; set; }
+
+        public override bool IsValid => Structure != StructureType.None;
+
+        protected override void WriteData(BinaryWriter writer, slocHeader header) => writer.Write((byte) Structure);
+
+        public enum StructureType : byte
+        {
+
+            None = 0,
+            Adrenaline = 1,
+            BinaryTarget = 2,
+            DboyTarget = 3,
+            EzBreakableDoor = 4,
+            Generator = 5,
+            HczBreakableDoor = 6,
+            LczBreakableDoor = 7,
+            LargeGunLocker = 8,
+            MiscellaneousLocker = 9,
+            Medkit = 10,
+            RifleRack = 11,
+            Scp018Pedestal = 12,
+            Scp207Pedestal = 13,
+            Scp244Pedestal = 14,
+            Scp268Pedestal = 15,
+            Scp500Pedestal = 16,
+            Scp1576Pedestal = 17,
+            Scp1853Pedestal = 18,
+            Scp2176Pedestal = 19,
+            SportTarget = 20,
+            Workstation = 21
+
+        }
+
+    }
+
+}

--- a/Scripts/slocExporter/Objects/StructureObject.cs
+++ b/Scripts/slocExporter/Objects/StructureObject.cs
@@ -7,6 +7,8 @@ namespace slocExporter.Objects
     public sealed class StructureObject : slocGameObject
     {
 
+        public const int RemoveDefaultLootBit = 0b1000_0000;
+
         public StructureObject(StructureType structureType) : this(0, structureType)
         {
         }
@@ -19,9 +21,12 @@ namespace slocExporter.Objects
 
         public StructureType Structure { get; set; }
 
+        public bool RemoveDefaultLoot { get; set; }
+
         public override bool IsValid => Structure != StructureType.None;
 
-        protected override void WriteData(BinaryWriter writer, slocHeader header) => writer.Write((byte) Structure);
+        protected override void WriteData(BinaryWriter writer, slocHeader header)
+            => writer.Write((byte) ((int) Structure | (RemoveDefaultLoot ? RemoveDefaultLootBit : 0)));
 
         public enum StructureType : byte
         {

--- a/Scripts/slocExporter/Objects/slocGameObject.cs
+++ b/Scripts/slocExporter/Objects/slocGameObject.cs
@@ -1,9 +1,11 @@
 ﻿using System.IO;
 using slocExporter.Readers;
 
-namespace slocExporter.Objects {
+namespace slocExporter.Objects
+{
 
-    public abstract class slocGameObject {
+    public abstract class slocGameObject
+    {
 
         protected slocGameObject(int instanceId) => InstanceId = instanceId;
 
@@ -19,7 +21,8 @@ namespace slocExporter.Objects {
 
         public virtual bool IsValid => Type != ObjectType.None;
 
-        public void WriteTo(BinaryWriter writer, slocHeader header) {
+        public void WriteTo(BinaryWriter writer, slocHeader header)
+        {
             writer.Write((byte) Type);
             writer.Write(InstanceId);
             writer.Write(ParentId);
@@ -27,7 +30,8 @@ namespace slocExporter.Objects {
             WriteData(writer, header);
         }
 
-        protected virtual void WriteData(BinaryWriter writer, slocHeader header) {
+        protected virtual void WriteData(BinaryWriter writer, slocHeader header)
+        {
         }
 
     }

--- a/Scripts/slocExporter/Objects/slocTransform.cs
+++ b/Scripts/slocExporter/Objects/slocTransform.cs
@@ -1,21 +1,25 @@
 ﻿using System.IO;
 using UnityEngine;
 
-namespace slocExporter.Objects {
+namespace slocExporter.Objects
+{
 
-    public sealed class slocTransform {
+    public sealed class slocTransform
+    {
 
         public Vector3 Position = Vector3.zero;
         public Vector3 Scale = Vector3.one;
         public Quaternion Rotation = Quaternion.identity;
 
-        public void WriteTo(BinaryWriter writer) {
+        public void WriteTo(BinaryWriter writer)
+        {
             writer.WriteVector(Position);
             writer.WriteVector(Scale);
             writer.WriteQuaternion(Rotation);
         }
 
-        public static implicit operator slocTransform(Transform transform) => new() {
+        public static implicit operator slocTransform(Transform transform) => new()
+        {
             Position = transform.localPosition,
             Scale = transform.localScale,
             Rotation = transform.localRotation

--- a/Scripts/slocExporter/Readers/IObjectReader.cs
+++ b/Scripts/slocExporter/Readers/IObjectReader.cs
@@ -1,9 +1,11 @@
 ﻿using System.IO;
 using slocExporter.Objects;
 
-namespace slocExporter.Readers {
+namespace slocExporter.Readers
+{
 
-    public interface IObjectReader {
+    public interface IObjectReader
+    {
 
         slocHeader ReadHeader(BinaryReader stream);
 

--- a/Scripts/slocExporter/Readers/Ver1Reader.cs
+++ b/Scripts/slocExporter/Readers/Ver1Reader.cs
@@ -1,15 +1,19 @@
 ﻿using System.IO;
 using slocExporter.Objects;
 
-namespace slocExporter.Readers {
+namespace slocExporter.Readers
+{
 
-    public sealed class Ver1Reader : IObjectReader {
+    public sealed class Ver1Reader : IObjectReader
+    {
 
         public slocHeader ReadHeader(BinaryReader stream) => new(1, stream.ReadObjectCount());
 
-        public slocGameObject Read(BinaryReader stream, slocHeader header) {
+        public slocGameObject Read(BinaryReader stream, slocHeader header)
+        {
             var objectType = (ObjectType) stream.ReadByte();
-            return objectType switch {
+            return objectType switch
+            {
                 ObjectType.Cube
                     or ObjectType.Sphere
                     or ObjectType.Cylinder
@@ -21,22 +25,26 @@ namespace slocExporter.Readers {
             };
         }
 
-        public static PrimitiveObject ReadPrimitive(BinaryReader stream, ObjectType type) {
+        public static PrimitiveObject ReadPrimitive(BinaryReader stream, ObjectType type)
+        {
             var transform = stream.ReadTransform();
             var materialColor = stream.ReadColor();
-            return new PrimitiveObject(0, type) {
+            return new PrimitiveObject(0, type)
+            {
                 Transform = transform,
                 MaterialColor = materialColor
             };
         }
 
-        public static LightObject ReadLight(BinaryReader stream) {
+        public static LightObject ReadLight(BinaryReader stream)
+        {
             var transform = stream.ReadTransform();
             var lightColor = stream.ReadColor();
             var shadows = stream.ReadBoolean();
             var range = stream.ReadSingle();
             var intensity = stream.ReadSingle();
-            return new LightObject(0) {
+            return new LightObject(0)
+            {
                 Transform = transform,
                 LightColor = lightColor,
                 Shadows = shadows,

--- a/Scripts/slocExporter/Readers/Ver2Reader.cs
+++ b/Scripts/slocExporter/Readers/Ver2Reader.cs
@@ -1,15 +1,19 @@
 ﻿using System.IO;
 using slocExporter.Objects;
 
-namespace slocExporter.Readers {
+namespace slocExporter.Readers
+{
 
-    public sealed class Ver2Reader : IObjectReader {
+    public sealed class Ver2Reader : IObjectReader
+    {
 
         public slocHeader ReadHeader(BinaryReader stream) => new(2, stream.ReadObjectCount());
 
-        public slocGameObject Read(BinaryReader stream, slocHeader header) {
+        public slocGameObject Read(BinaryReader stream, slocHeader header)
+        {
             var objectType = (ObjectType) stream.ReadByte();
-            return objectType switch {
+            return objectType switch
+            {
                 ObjectType.Cube
                     or ObjectType.Sphere
                     or ObjectType.Cylinder
@@ -22,19 +26,22 @@ namespace slocExporter.Readers {
             };
         }
 
-        public static PrimitiveObject ReadPrimitive(BinaryReader stream, ObjectType type) {
+        public static PrimitiveObject ReadPrimitive(BinaryReader stream, ObjectType type)
+        {
             var instanceId = stream.ReadInt32();
             var parentId = stream.ReadInt32();
             var transform = stream.ReadTransform();
             var materialColor = stream.ReadColor();
-            return new PrimitiveObject(instanceId, type) {
+            return new PrimitiveObject(instanceId, type)
+            {
                 ParentId = parentId,
                 Transform = transform,
                 MaterialColor = materialColor
             };
         }
 
-        public static LightObject ReadLight(BinaryReader stream) {
+        public static LightObject ReadLight(BinaryReader stream)
+        {
             var instanceId = stream.ReadInt32();
             var parentId = stream.ReadInt32();
             var transform = stream.ReadTransform();
@@ -42,7 +49,8 @@ namespace slocExporter.Readers {
             var shadows = stream.ReadBoolean();
             var range = stream.ReadSingle();
             var intensity = stream.ReadSingle();
-            return new LightObject(instanceId) {
+            return new LightObject(instanceId)
+            {
                 ParentId = parentId,
                 Transform = transform,
                 LightColor = lightColor,
@@ -52,11 +60,13 @@ namespace slocExporter.Readers {
             };
         }
 
-        public static EmptyObject ReadEmpty(BinaryReader stream) {
+        public static EmptyObject ReadEmpty(BinaryReader stream)
+        {
             var instanceId = stream.ReadInt32();
             var parentId = stream.ReadInt32();
             var transform = stream.ReadTransform();
-            return new EmptyObject(instanceId) {
+            return new EmptyObject(instanceId)
+            {
                 ParentId = parentId,
                 Transform = transform
             };

--- a/Scripts/slocExporter/Readers/Ver3Reader.cs
+++ b/Scripts/slocExporter/Readers/Ver3Reader.cs
@@ -2,15 +2,19 @@
 using slocExporter.Objects;
 using UnityEngine;
 
-namespace slocExporter.Readers {
+namespace slocExporter.Readers
+{
 
-    public sealed class Ver3Reader : IObjectReader {
+    public sealed class Ver3Reader : IObjectReader
+    {
 
         public slocHeader ReadHeader(BinaryReader stream) => ReadHeaderStatic(stream, 3);
 
-        public slocGameObject Read(BinaryReader stream, slocHeader header) {
+        public slocGameObject Read(BinaryReader stream, slocHeader header)
+        {
             var objectType = (ObjectType) stream.ReadByte();
-            return objectType switch {
+            return objectType switch
+            {
                 ObjectType.Cube
                     or ObjectType.Sphere
                     or ObjectType.Cylinder
@@ -23,7 +27,8 @@ namespace slocExporter.Readers {
             };
         }
 
-        public static slocHeader ReadHeaderStatic(BinaryReader stream, ushort version) {
+        public static slocHeader ReadHeaderStatic(BinaryReader stream, ushort version)
+        {
             var count = stream.ReadObjectCount();
             var attributes = (slocAttributes) stream.ReadByte();
             var colliderCreationMode = attributes.HasFlagFast(slocAttributes.DefaultColliderMode)
@@ -37,7 +42,8 @@ namespace slocExporter.Readers {
             );
         }
 
-        public static PrimitiveObject ReadPrimitive(BinaryReader stream, ObjectType type, slocHeader header) {
+        public static PrimitiveObject ReadPrimitive(BinaryReader stream, ObjectType type, slocHeader header)
+        {
             var instanceId = stream.ReadInt32();
             var parentId = stream.ReadInt32();
             var slocTransform = stream.ReadTransform();
@@ -46,7 +52,8 @@ namespace slocExporter.Readers {
             var creationMode = colliderCreationMode is PrimitiveObject.ColliderCreationMode.Unset && header.HasAttribute(slocAttributes.DefaultColliderMode)
                 ? header.DefaultColliderMode
                 : colliderCreationMode;
-            return new PrimitiveObject(instanceId, type) {
+            return new PrimitiveObject(instanceId, type)
+            {
                 ParentId = parentId,
                 Transform = slocTransform,
                 MaterialColor = color,
@@ -54,7 +61,8 @@ namespace slocExporter.Readers {
             };
         }
 
-        public static LightObject ReadLight(BinaryReader stream, slocHeader header) {
+        public static LightObject ReadLight(BinaryReader stream, slocHeader header)
+        {
             var instanceId = stream.ReadInt32();
             var parentId = stream.ReadInt32();
             var transform = stream.ReadTransform();
@@ -62,7 +70,8 @@ namespace slocExporter.Readers {
             var shadows = stream.ReadBoolean();
             var range = stream.ReadSingle();
             var intensity = stream.ReadSingle();
-            return new LightObject(instanceId) {
+            return new LightObject(instanceId)
+            {
                 ParentId = parentId,
                 Transform = transform,
                 LightColor = lightColor,

--- a/Scripts/slocExporter/Readers/Ver4Reader.cs
+++ b/Scripts/slocExporter/Readers/Ver4Reader.cs
@@ -2,15 +2,19 @@
 using slocExporter.Objects;
 using slocExporter.TriggerActions;
 
-namespace slocExporter.Readers {
+namespace slocExporter.Readers
+{
 
-    public sealed class Ver4Reader : IObjectReader {
+    public sealed class Ver4Reader : IObjectReader
+    {
 
         public slocHeader ReadHeader(BinaryReader stream) => Ver3Reader.ReadHeaderStatic(stream, 4);
 
-        public slocGameObject Read(BinaryReader stream, slocHeader header) {
+        public slocGameObject Read(BinaryReader stream, slocHeader header)
+        {
             var objectType = (ObjectType) stream.ReadByte();
-            return objectType switch {
+            return objectType switch
+            {
                 ObjectType.Cube
                     or ObjectType.Sphere
                     or ObjectType.Cylinder
@@ -23,7 +27,8 @@ namespace slocExporter.Readers {
             };
         }
 
-        public static slocGameObject ReadPrimitive(BinaryReader stream, ObjectType type, slocHeader header) {
+        public static slocGameObject ReadPrimitive(BinaryReader stream, ObjectType type, slocHeader header)
+        {
             var primitive = Ver3Reader.ReadPrimitive(stream, type, header);
             if (!primitive.ColliderMode.IsTrigger() && !header.HasAttribute(slocAttributes.ExportAllTriggerActions))
                 return primitive;

--- a/Scripts/slocExporter/Readers/Ver5Reader.cs
+++ b/Scripts/slocExporter/Readers/Ver5Reader.cs
@@ -1,0 +1,45 @@
+﻿using System.IO;
+using slocExporter.Objects;
+
+namespace slocExporter.Readers
+{
+
+    public sealed class Ver5Reader : IObjectReader
+    {
+
+        public slocHeader ReadHeader(BinaryReader stream) => Ver3Reader.ReadHeaderStatic(stream, 5);
+
+        public slocGameObject Read(BinaryReader stream, slocHeader header)
+        {
+            var objectType = (ObjectType) stream.ReadByte();
+            return objectType switch
+            {
+                ObjectType.Structure => ReadStructure(stream),
+                ObjectType.Cube
+                    or ObjectType.Sphere
+                    or ObjectType.Cylinder
+                    or ObjectType.Plane
+                    or ObjectType.Capsule
+                    or ObjectType.Quad => Ver4Reader.ReadPrimitive(stream, objectType, header),
+                ObjectType.Light => Ver3Reader.ReadLight(stream, header),
+                ObjectType.Empty => Ver2Reader.ReadEmpty(stream),
+                _ => null
+            };
+        }
+
+        public static StructureObject ReadStructure(BinaryReader stream)
+        {
+            var instanceId = stream.ReadInt32();
+            var parentId = stream.ReadInt32();
+            var transform = stream.ReadTransform();
+            var structureType = (StructureObject.StructureType) stream.ReadByte();
+            return new StructureObject(instanceId, structureType)
+            {
+                ParentId = parentId,
+                Transform = transform
+            };
+        }
+
+    }
+
+}

--- a/Scripts/slocExporter/Readers/Ver5Reader.cs
+++ b/Scripts/slocExporter/Readers/Ver5Reader.cs
@@ -32,11 +32,12 @@ namespace slocExporter.Readers
             var instanceId = stream.ReadInt32();
             var parentId = stream.ReadInt32();
             var transform = stream.ReadTransform();
-            var structureType = (StructureObject.StructureType) stream.ReadByte();
-            return new StructureObject(instanceId, structureType)
+            var typeData = stream.ReadByte();
+            return new StructureObject(instanceId, (StructureObject.StructureType) (typeData & ~StructureObject.RemoveDefaultLootBit))
             {
                 ParentId = parentId,
-                Transform = transform
+                Transform = transform,
+                RemoveDefaultLoot = (typeData & StructureObject.RemoveDefaultLootBit) != 0
             };
         }
 

--- a/Scripts/slocExporter/Readers/slocHeader.cs
+++ b/Scripts/slocExporter/Readers/slocHeader.cs
@@ -1,9 +1,11 @@
 ﻿using System.IO;
 using slocExporter.Objects;
 
-namespace slocExporter.Readers {
+namespace slocExporter.Readers
+{
 
-    public readonly struct slocHeader {
+    public readonly struct slocHeader
+    {
 
         public readonly ushort Version;
 
@@ -13,21 +15,24 @@ namespace slocExporter.Readers {
 
         public readonly PrimitiveObject.ColliderCreationMode DefaultColliderMode;
 
-        public slocHeader(ushort version, int objectCount, slocAttributes attributes = slocAttributes.None, PrimitiveObject.ColliderCreationMode defaultColliderMode = PrimitiveObject.ColliderCreationMode.Unset) {
+        public slocHeader(ushort version, int objectCount, slocAttributes attributes = slocAttributes.None, PrimitiveObject.ColliderCreationMode defaultColliderMode = PrimitiveObject.ColliderCreationMode.Unset)
+        {
             ObjectCount = objectCount;
             Version = version;
             Attributes = attributes;
             DefaultColliderMode = defaultColliderMode;
         }
 
-        public slocHeader(ushort version, int objectCount, byte attributes, PrimitiveObject.ColliderCreationMode defaultColliderMode = PrimitiveObject.ColliderCreationMode.Unset) {
+        public slocHeader(ushort version, int objectCount, byte attributes, PrimitiveObject.ColliderCreationMode defaultColliderMode = PrimitiveObject.ColliderCreationMode.Unset)
+        {
             ObjectCount = objectCount;
             Version = version;
             Attributes = (slocAttributes) attributes;
             DefaultColliderMode = defaultColliderMode;
         }
 
-        public void WriteTo(BinaryWriter writer) {
+        public void WriteTo(BinaryWriter writer)
+        {
             writer.Write(ObjectCount);
             writer.Write((byte) Attributes);
             if (Attributes.HasFlagFast(slocAttributes.DefaultColliderMode))

--- a/Scripts/slocExporter/StructureOverride.cs
+++ b/Scripts/slocExporter/StructureOverride.cs
@@ -1,0 +1,17 @@
+﻿using slocExporter.Objects;
+using UnityEngine;
+
+namespace slocExporter
+{
+
+    [DisallowMultipleComponent]
+    public sealed class StructureOverride : MonoBehaviour
+    {
+
+        public StructureObject.StructureType type;
+
+        public bool removeDefaultLoot;
+
+    }
+
+}

--- a/Scripts/slocExporter/TriggerActionGizmosDrawer.cs
+++ b/Scripts/slocExporter/TriggerActionGizmosDrawer.cs
@@ -1,6 +1,7 @@
 ﻿using slocExporter.TriggerActions;
 
-namespace slocExporter {
+namespace slocExporter
+{
 
     public delegate void TriggerActionGizmosDrawer(TriggerAction instance);
 

--- a/Scripts/slocExporter/TriggerActions/ActionManager.cs
+++ b/Scripts/slocExporter/TriggerActions/ActionManager.cs
@@ -5,44 +5,52 @@ using slocExporter.TriggerActions.Data;
 using slocExporter.TriggerActions.Enums;
 using slocExporter.TriggerActions.Readers;
 
-namespace slocExporter.TriggerActions {
+namespace slocExporter.TriggerActions
+{
 
-    public static class ActionManager {
+    public static class ActionManager
+    {
 
         public const ushort MinVersion = 4;
 
         private static readonly ITriggerActionDataReader DefaultReader = new Ver4ActionDataReader();
 
-        private static readonly Dictionary<ushort, ITriggerActionDataReader> Readers = new() {
+        private static readonly Dictionary<ushort, ITriggerActionDataReader> Readers = new()
+        {
             {4, new Ver4ActionDataReader()}
         };
 
-        public static readonly ICollection<TargetType> TargetTypeValues = new List<TargetType> {
+        public static readonly ICollection<TargetType> TargetTypeValues = new List<TargetType>
+        {
             TargetType.Player,
             TargetType.Pickup,
             TargetType.Toy,
             TargetType.Ragdoll
         }.AsReadOnly();
 
-        public static readonly ICollection<TriggerEventType> EventTypeValues = new List<TriggerEventType> {
+        public static readonly ICollection<TriggerEventType> EventTypeValues = new List<TriggerEventType>
+        {
             TriggerEventType.Enter,
             TriggerEventType.Stay,
             TriggerEventType.Exit
         }.AsReadOnly();
 
-        public static readonly ICollection<TeleportOptions> TeleportOptionsValues = new List<TeleportOptions> {
+        public static readonly ICollection<TeleportOptions> TeleportOptionsValues = new List<TeleportOptions>
+        {
             TeleportOptions.ResetFallDamage,
             TeleportOptions.ResetVelocity,
             TeleportOptions.WorldSpaceTransform
         }.AsReadOnly();
 
-        public static readonly Dictionary<TeleportOptions, string> TeleportOptionsNames = new() {
+        public static readonly Dictionary<TeleportOptions, string> TeleportOptionsNames = new()
+        {
             {TeleportOptions.ResetFallDamage, "Reset Fall Damage"},
             {TeleportOptions.ResetVelocity, "Reset Velocity"},
             {TeleportOptions.WorldSpaceTransform, "World-Space Transform"}
         };
 
-        public static bool TryGetReader(ushort version, out ITriggerActionDataReader reader) {
+        public static bool TryGetReader(ushort version, out ITriggerActionDataReader reader)
+        {
             reader = null;
             if (version < MinVersion)
                 return Readers.TryGetValue(version, out reader);
@@ -52,18 +60,21 @@ namespace slocExporter.TriggerActions {
 
         public static ITriggerActionDataReader GetReader(ushort version) => TryGetReader(version, out var reader) ? reader : DefaultReader;
 
-        public static void WriteActions(BinaryWriter writer, ICollection<BaseTriggerActionData> actions) {
+        public static void WriteActions(BinaryWriter writer, ICollection<BaseTriggerActionData> actions)
+        {
             writer.Write(actions.Count);
             foreach (var data in actions)
                 data.WriteTo(writer);
         }
 
-        public static BaseTriggerActionData[] ReadActions(BinaryReader stream, ITriggerActionDataReader reader) {
+        public static BaseTriggerActionData[] ReadActions(BinaryReader stream, ITriggerActionDataReader reader)
+        {
             var actionCount = stream.ReadInt32();
             if (actionCount < 1)
                 return Array.Empty<BaseTriggerActionData>();
             var actions = new List<BaseTriggerActionData>();
-            for (var i = 0; i < actionCount; i++) {
+            for (var i = 0; i < actionCount; i++)
+            {
                 var action = reader.Read(stream);
                 if (action != null)
                     actions.Add(action);
@@ -73,7 +84,8 @@ namespace slocExporter.TriggerActions {
             return array;
         }
 
-        public static void ReadTypes(BinaryReader reader, out TriggerActionType actionType, out TargetType targetType, out TriggerEventType eventType) {
+        public static void ReadTypes(BinaryReader reader, out TriggerActionType actionType, out TargetType targetType, out TriggerEventType eventType)
+        {
             actionType = (TriggerActionType) reader.ReadUInt16();
             var combined = reader.ReadByte();
             API.SplitSafe(combined, out var target, out var eventTypes);

--- a/Scripts/slocExporter/TriggerActions/ActionManager.cs
+++ b/Scripts/slocExporter/TriggerActions/ActionManager.cs
@@ -13,11 +13,12 @@ namespace slocExporter.TriggerActions
 
         public const ushort MinVersion = 4;
 
-        private static readonly ITriggerActionDataReader DefaultReader = new Ver4ActionDataReader();
+        private static readonly ITriggerActionDataReader DefaultReader = new Ver5ActionDataReader();
 
         private static readonly Dictionary<ushort, ITriggerActionDataReader> Readers = new()
         {
-            {4, new Ver4ActionDataReader()}
+            {4, new Ver4ActionDataReader()},
+            {5, DefaultReader}
         };
 
         public static readonly ICollection<TargetType> TargetTypeValues = new List<TargetType>
@@ -39,15 +40,9 @@ namespace slocExporter.TriggerActions
         {
             TeleportOptions.ResetFallDamage,
             TeleportOptions.ResetVelocity,
-            TeleportOptions.WorldSpaceTransform
+            TeleportOptions.WorldSpaceTransform,
+            TeleportOptions.DeltaRotation
         }.AsReadOnly();
-
-        public static readonly Dictionary<TeleportOptions, string> TeleportOptionsNames = new()
-        {
-            {TeleportOptions.ResetFallDamage, "Reset Fall Damage"},
-            {TeleportOptions.ResetVelocity, "Reset Velocity"},
-            {TeleportOptions.WorldSpaceTransform, "World-Space Transform"}
-        };
 
         public static bool TryGetReader(ushort version, out ITriggerActionDataReader reader)
         {
@@ -103,7 +98,7 @@ namespace slocExporter.TriggerActions
 
         public static bool HasFlagFast(this TeleportOptions options, TeleportOptions flag) => (options & flag) == flag;
 
-        public static bool Is(this TeleportOptions type, TeleportOptions isType) => type is TeleportOptions.None || type.HasFlagFast(isType);
+        public static bool Is(this TeleportOptions type, TeleportOptions isType) => type is TeleportOptions.All || type.HasFlagFast(isType);
 
     }
 

--- a/Scripts/slocExporter/TriggerActions/Data/BaseTeleportData.cs
+++ b/Scripts/slocExporter/TriggerActions/Data/BaseTeleportData.cs
@@ -2,9 +2,11 @@
 using slocExporter.TriggerActions.Enums;
 using UnityEngine;
 
-namespace slocExporter.TriggerActions.Data {
+namespace slocExporter.TriggerActions.Data
+{
 
-    public abstract class BaseTeleportData : BaseTriggerActionData {
+    public abstract class BaseTeleportData : BaseTriggerActionData
+    {
 
         [field: SerializeField]
         public Vector3 Position { get; set; }
@@ -12,13 +14,15 @@ namespace slocExporter.TriggerActions.Data {
         [field: SerializeField]
         public TeleportOptions Options { get; set; }
 
-        protected sealed override void WriteData(BinaryWriter writer) {
+        protected sealed override void WriteData(BinaryWriter writer)
+        {
             writer.WriteVector(Position);
             writer.Write((byte) Options);
             WriteAdditionalData(writer);
         }
 
-        protected virtual void WriteAdditionalData(BinaryWriter writer) {
+        protected virtual void WriteAdditionalData(BinaryWriter writer)
+        {
         }
 
         public Vector3 ToWorldSpacePosition(Transform reference) =>

--- a/Scripts/slocExporter/TriggerActions/Data/BaseTeleportData.cs
+++ b/Scripts/slocExporter/TriggerActions/Data/BaseTeleportData.cs
@@ -12,7 +12,7 @@ namespace slocExporter.TriggerActions.Data
         public Vector3 Position { get; set; }
 
         [field: SerializeField]
-        public TeleportOptions Options { get; set; }
+        public TeleportOptions Options { get; set; } = TeleportOptions.ResetFallDamage | TeleportOptions.DeltaRotation;
 
         [field: SerializeField]
         public float RotationY { get; set; }

--- a/Scripts/slocExporter/TriggerActions/Data/BaseTeleportData.cs
+++ b/Scripts/slocExporter/TriggerActions/Data/BaseTeleportData.cs
@@ -14,10 +14,14 @@ namespace slocExporter.TriggerActions.Data
         [field: SerializeField]
         public TeleportOptions Options { get; set; }
 
+        [field: SerializeField]
+        public float RotationY { get; set; }
+
         protected sealed override void WriteData(BinaryWriter writer)
         {
             writer.WriteVector(Position);
             writer.Write((byte) Options);
+            writer.Write(RotationY);
             WriteAdditionalData(writer);
         }
 
@@ -29,6 +33,14 @@ namespace slocExporter.TriggerActions.Data
             Options.HasFlag(TeleportOptions.WorldSpaceTransform)
                 ? reference.position + Position
                 : reference.TransformPoint(Position);
+
+        public void ToWorldSpace(Transform reference, out Vector3 position, out float rotation)
+        {
+            position = ToWorldSpacePosition(reference);
+            rotation = Options.HasFlag(TeleportOptions.WorldSpaceTransform)
+                ? RotationY
+                : reference.rotation.eulerAngles.y + RotationY;
+        }
 
     }
 

--- a/Scripts/slocExporter/TriggerActions/Data/BaseTriggerActionData.cs
+++ b/Scripts/slocExporter/TriggerActions/Data/BaseTriggerActionData.cs
@@ -3,10 +3,12 @@ using System.IO;
 using slocExporter.TriggerActions.Enums;
 using UnityEngine;
 
-namespace slocExporter.TriggerActions.Data {
+namespace slocExporter.TriggerActions.Data
+{
 
     [Serializable]
-    public abstract class BaseTriggerActionData {
+    public abstract class BaseTriggerActionData
+    {
 
         [SerializeField]
         private TargetType selectedTargets;
@@ -15,10 +17,13 @@ namespace slocExporter.TriggerActions.Data {
 
         public abstract TriggerActionType ActionType { get; }
 
-        public TargetType SelectedTargets {
+        public TargetType SelectedTargets
+        {
             get => selectedTargets;
-            set {
-                if (value is TargetType.None) {
+            set
+            {
+                if (value is TargetType.None)
+                {
                     selectedTargets = value;
                     return;
                 }
@@ -37,13 +42,15 @@ namespace slocExporter.TriggerActions.Data {
 
         protected BaseTriggerActionData() => SelectedTargets = TargetType.All;
 
-        public void WriteTo(BinaryWriter writer) {
+        public void WriteTo(BinaryWriter writer)
+        {
             writer.Write((ushort) ActionType);
             writer.Write(API.CombineSafe((byte) SelectedTargets, (byte) SelectedEvents));
             WriteData(writer);
         }
 
-        protected virtual void WriteData(BinaryWriter writer) {
+        protected virtual void WriteData(BinaryWriter writer)
+        {
         }
 
     }

--- a/Scripts/slocExporter/TriggerActions/Data/KillPlayerData.cs
+++ b/Scripts/slocExporter/TriggerActions/Data/KillPlayerData.cs
@@ -2,9 +2,11 @@
 using slocExporter.TriggerActions.Enums;
 using UnityEngine;
 
-namespace slocExporter.TriggerActions.Data {
+namespace slocExporter.TriggerActions.Data
+{
 
-    public sealed class KillPlayerData : BaseTriggerActionData {
+    public sealed class KillPlayerData : BaseTriggerActionData
+    {
 
         public override TargetType PossibleTargets => TargetType.Player;
 

--- a/Scripts/slocExporter/TriggerActions/Data/MoveRelativeToSelfData.cs
+++ b/Scripts/slocExporter/TriggerActions/Data/MoveRelativeToSelfData.cs
@@ -1,9 +1,11 @@
 ﻿using slocExporter.TriggerActions.Enums;
 using UnityEngine;
 
-namespace slocExporter.TriggerActions.Data {
+namespace slocExporter.TriggerActions.Data
+{
 
-    public sealed class MoveRelativeToSelfData : BaseTeleportData {
+    public sealed class MoveRelativeToSelfData : BaseTeleportData
+    {
 
         public override TargetType PossibleTargets => TargetType.All;
 

--- a/Scripts/slocExporter/TriggerActions/Data/RuntimeTeleportToSpawnedObjectData.cs
+++ b/Scripts/slocExporter/TriggerActions/Data/RuntimeTeleportToSpawnedObjectData.cs
@@ -2,9 +2,11 @@ using System.IO;
 using slocExporter.TriggerActions.Enums;
 using UnityEngine;
 
-namespace slocExporter.TriggerActions.Data {
+namespace slocExporter.TriggerActions.Data
+{
 
-    public sealed class RuntimeTeleportToSpawnedObjectData : BaseTeleportData {
+    public sealed class RuntimeTeleportToSpawnedObjectData : BaseTeleportData
+    {
 
         public override TargetType PossibleTargets => TargetType.All;
 
@@ -13,7 +15,8 @@ namespace slocExporter.TriggerActions.Data {
         [field: SerializeField]
         public GameObject Target { get; set; }
 
-        public RuntimeTeleportToSpawnedObjectData(GameObject target, Vector3 offset) {
+        public RuntimeTeleportToSpawnedObjectData(GameObject target, Vector3 offset)
+        {
             Target = target;
             Position = offset;
         }

--- a/Scripts/slocExporter/TriggerActions/Data/SerializableTeleportToSpawnedObjectData.cs
+++ b/Scripts/slocExporter/TriggerActions/Data/SerializableTeleportToSpawnedObjectData.cs
@@ -2,9 +2,11 @@
 using slocExporter.TriggerActions.Enums;
 using UnityEngine;
 
-namespace slocExporter.TriggerActions.Data {
+namespace slocExporter.TriggerActions.Data
+{
 
-    public sealed class SerializableTeleportToSpawnedObjectData : BaseTriggerActionData {
+    public sealed class SerializableTeleportToSpawnedObjectData : BaseTriggerActionData
+    {
 
         public override TargetType PossibleTargets => TargetType.All;
 
@@ -16,13 +18,15 @@ namespace slocExporter.TriggerActions.Data {
 
         public readonly TeleportOptions Options;
 
-        public SerializableTeleportToSpawnedObjectData(int id, Vector3 offset, TeleportOptions options) {
+        public SerializableTeleportToSpawnedObjectData(int id, Vector3 offset, TeleportOptions options)
+        {
             ID = id;
             Offset = offset;
             Options = options;
         }
 
-        protected override void WriteData(BinaryWriter writer) {
+        protected override void WriteData(BinaryWriter writer)
+        {
             writer.Write(ID);
             writer.WriteVector(Offset);
             writer.Write((byte) Options);

--- a/Scripts/slocExporter/TriggerActions/Data/SerializableTeleportToSpawnedObjectData.cs
+++ b/Scripts/slocExporter/TriggerActions/Data/SerializableTeleportToSpawnedObjectData.cs
@@ -16,13 +16,20 @@ namespace slocExporter.TriggerActions.Data
 
         public readonly Vector3 Offset;
 
+        public readonly float RotationY;
+
         public readonly TeleportOptions Options;
 
-        public SerializableTeleportToSpawnedObjectData(int id, Vector3 offset, TeleportOptions options)
+        public SerializableTeleportToSpawnedObjectData(int id, Vector3 offset, TeleportOptions options) : this(id, offset, options, 0)
+        {
+        }
+
+        public SerializableTeleportToSpawnedObjectData(int id, Vector3 offset, TeleportOptions options, float rotationY)
         {
             ID = id;
             Offset = offset;
             Options = options;
+            RotationY = rotationY;
         }
 
         protected override void WriteData(BinaryWriter writer)
@@ -30,6 +37,7 @@ namespace slocExporter.TriggerActions.Data
             writer.Write(ID);
             writer.WriteVector(Offset);
             writer.Write((byte) Options);
+            writer.Write(RotationY);
         }
 
     }

--- a/Scripts/slocExporter/TriggerActions/Data/TeleportToPositionData.cs
+++ b/Scripts/slocExporter/TriggerActions/Data/TeleportToPositionData.cs
@@ -1,9 +1,11 @@
 ﻿using slocExporter.TriggerActions.Enums;
 using UnityEngine;
 
-namespace slocExporter.TriggerActions.Data {
+namespace slocExporter.TriggerActions.Data
+{
 
-    public sealed class TeleportToPositionData : BaseTeleportData {
+    public sealed class TeleportToPositionData : BaseTeleportData
+    {
 
         public override TargetType PossibleTargets => TargetType.All;
 

--- a/Scripts/slocExporter/TriggerActions/Data/TeleportToRoomData.cs
+++ b/Scripts/slocExporter/TriggerActions/Data/TeleportToRoomData.cs
@@ -2,9 +2,11 @@
 using slocExporter.TriggerActions.Enums;
 using UnityEngine;
 
-namespace slocExporter.TriggerActions.Data {
+namespace slocExporter.TriggerActions.Data
+{
 
-    public sealed class TeleportToRoomData : BaseTeleportData {
+    public sealed class TeleportToRoomData : BaseTeleportData
+    {
 
         public override TargetType PossibleTargets => TargetType.All;
 
@@ -13,7 +15,8 @@ namespace slocExporter.TriggerActions.Data {
         [field: SerializeField]
         public string Room { get; set; }
 
-        public TeleportToRoomData(string room, Vector3 offset) {
+        public TeleportToRoomData(string room, Vector3 offset)
+        {
             Room = room;
             Position = offset;
         }

--- a/Scripts/slocExporter/TriggerActions/Data/TeleporterImmunityData.cs
+++ b/Scripts/slocExporter/TriggerActions/Data/TeleporterImmunityData.cs
@@ -2,9 +2,11 @@
 using slocExporter.TriggerActions.Enums;
 using UnityEngine;
 
-namespace slocExporter.TriggerActions.Data {
+namespace slocExporter.TriggerActions.Data
+{
 
-    public sealed class TeleporterImmunityData : BaseTriggerActionData {
+    public sealed class TeleporterImmunityData : BaseTriggerActionData
+    {
 
         public const float MaxValue = 60f;
         public const float FloatToShortMultiplier = 1000f;
@@ -23,13 +25,15 @@ namespace slocExporter.TriggerActions.Data {
         [field: SerializeField]
         public float Duration { get; set; }
 
-        public TeleporterImmunityData(bool isGlobal, ImmunityDurationMode durationMode, float duration) {
+        public TeleporterImmunityData(bool isGlobal, ImmunityDurationMode durationMode, float duration)
+        {
             IsGlobal = isGlobal;
             DurationMode = durationMode;
             Duration = duration;
         }
 
-        protected override void WriteData(BinaryWriter writer) {
+        protected override void WriteData(BinaryWriter writer)
+        {
             writer.Write(API.CombineSafe((byte) (IsGlobal ? 1 : 0), (byte) DurationMode));
             writer.WriteFloatAsShort(Duration);
         }

--- a/Scripts/slocExporter/TriggerActions/Enums/ImmunityDurationMode.cs
+++ b/Scripts/slocExporter/TriggerActions/Enums/ImmunityDurationMode.cs
@@ -1,6 +1,8 @@
-﻿namespace slocExporter.TriggerActions.Enums {
+﻿namespace slocExporter.TriggerActions.Enums
+{
 
-    public enum ImmunityDurationMode : byte {
+    public enum ImmunityDurationMode : byte
+    {
 
         Absolute = 0,
         Add = 1,

--- a/Scripts/slocExporter/TriggerActions/Enums/TargetType.cs
+++ b/Scripts/slocExporter/TriggerActions/Enums/TargetType.cs
@@ -1,9 +1,11 @@
 ﻿using System;
 
-namespace slocExporter.TriggerActions.Enums {
+namespace slocExporter.TriggerActions.Enums
+{
 
     [Flags]
-    public enum TargetType : byte {
+    public enum TargetType : byte
+    {
 
         None = 0,
         Player = 1,

--- a/Scripts/slocExporter/TriggerActions/Enums/TeleportOptions.cs
+++ b/Scripts/slocExporter/TriggerActions/Enums/TeleportOptions.cs
@@ -1,9 +1,11 @@
 ﻿using System;
 
-namespace slocExporter.TriggerActions.Enums {
+namespace slocExporter.TriggerActions.Enums
+{
 
     [Flags]
-    public enum TeleportOptions : byte {
+    public enum TeleportOptions : byte
+    {
 
         None = 0,
         ResetFallDamage = 1,

--- a/Scripts/slocExporter/TriggerActions/Enums/TeleportOptions.cs
+++ b/Scripts/slocExporter/TriggerActions/Enums/TeleportOptions.cs
@@ -11,7 +11,8 @@ namespace slocExporter.TriggerActions.Enums
         ResetFallDamage = 1,
         ResetVelocity = 2,
         WorldSpaceTransform = 4,
-        All = ResetFallDamage | ResetVelocity | WorldSpaceTransform
+        DeltaRotation = 8,
+        All = ResetFallDamage | ResetVelocity | WorldSpaceTransform | DeltaRotation
 
     }
 

--- a/Scripts/slocExporter/TriggerActions/Enums/TriggerActionType.cs
+++ b/Scripts/slocExporter/TriggerActions/Enums/TriggerActionType.cs
@@ -1,6 +1,8 @@
-﻿namespace slocExporter.TriggerActions.Enums {
+﻿namespace slocExporter.TriggerActions.Enums
+{
 
-    public enum TriggerActionType : ushort {
+    public enum TriggerActionType : ushort
+    {
 
         None = 0,
         TeleportToPosition = 1,

--- a/Scripts/slocExporter/TriggerActions/Enums/TriggerEventType.cs
+++ b/Scripts/slocExporter/TriggerActions/Enums/TriggerEventType.cs
@@ -1,9 +1,11 @@
 ﻿using System;
 
-namespace slocExporter.TriggerActions.Enums {
+namespace slocExporter.TriggerActions.Enums
+{
 
     [Flags]
-    public enum TriggerEventType : byte {
+    public enum TriggerEventType : byte
+    {
 
         None = 0,
         Enter = 1,

--- a/Scripts/slocExporter/TriggerActions/Readers/ITriggerActionDataReader.cs
+++ b/Scripts/slocExporter/TriggerActions/Readers/ITriggerActionDataReader.cs
@@ -1,9 +1,11 @@
 ﻿using System.IO;
 using slocExporter.TriggerActions.Data;
 
-namespace slocExporter.TriggerActions.Readers {
+namespace slocExporter.TriggerActions.Readers
+{
 
-    public interface ITriggerActionDataReader {
+    public interface ITriggerActionDataReader
+    {
 
         BaseTriggerActionData Read(BinaryReader reader);
 

--- a/Scripts/slocExporter/TriggerActions/Readers/Ver4ActionDataReader.cs
+++ b/Scripts/slocExporter/TriggerActions/Readers/Ver4ActionDataReader.cs
@@ -3,13 +3,17 @@ using slocExporter.TriggerActions.Data;
 using slocExporter.TriggerActions.Enums;
 using UnityEngine;
 
-namespace slocExporter.TriggerActions.Readers {
+namespace slocExporter.TriggerActions.Readers
+{
 
-    public sealed class Ver4ActionDataReader : ITriggerActionDataReader {
+    public sealed class Ver4ActionDataReader : ITriggerActionDataReader
+    {
 
-        public BaseTriggerActionData Read(BinaryReader reader) {
+        public BaseTriggerActionData Read(BinaryReader reader)
+        {
             ActionManager.ReadTypes(reader, out var actionType, out var targetType, out var eventType);
-            BaseTriggerActionData data = actionType switch {
+            BaseTriggerActionData data = actionType switch
+            {
                 TriggerActionType.TeleportToPosition => ReadTpToPos(reader),
                 TriggerActionType.MoveRelativeToSelf => ReadMoveRelative(reader),
                 TriggerActionType.TeleportToRoom => ReadTpToRoom(reader),
@@ -25,41 +29,48 @@ namespace slocExporter.TriggerActions.Readers {
             return data;
         }
 
-        public static TeleportToPositionData ReadTpToPos(BinaryReader reader) {
+        public static TeleportToPositionData ReadTpToPos(BinaryReader reader)
+        {
             ReadTeleportData(reader, out var position, out var options);
             return new TeleportToPositionData(position) {Options = options};
         }
 
-        public static MoveRelativeToSelfData ReadMoveRelative(BinaryReader reader) {
+        public static MoveRelativeToSelfData ReadMoveRelative(BinaryReader reader)
+        {
             ReadTeleportData(reader, out var position, out var options);
             return new MoveRelativeToSelfData(position) {Options = options};
         }
 
-        public static TeleportToRoomData ReadTpToRoom(BinaryReader reader) {
+        public static TeleportToRoomData ReadTpToRoom(BinaryReader reader)
+        {
             ReadTeleportData(reader, out var position, out var options);
             var name = reader.ReadString();
             return new TeleportToRoomData(name, position) {Options = options};
         }
 
-        public static KillPlayerData ReadKillPlayer(BinaryReader reader) {
+        public static KillPlayerData ReadKillPlayer(BinaryReader reader)
+        {
             var cause = reader.ReadString();
             return new KillPlayerData(cause);
         }
 
-        public static SerializableTeleportToSpawnedObjectData ReadTpToSpawnedObject(BinaryReader reader) {
+        public static SerializableTeleportToSpawnedObjectData ReadTpToSpawnedObject(BinaryReader reader)
+        {
             ReadTeleportData(reader, out var offset, out var options);
             var virtualInstanceId = reader.ReadInt32();
             return new SerializableTeleportToSpawnedObjectData(virtualInstanceId, offset, options);
         }
 
-        public static TeleporterImmunityData ReadTeleporterImmunity(BinaryReader reader) {
+        public static TeleporterImmunityData ReadTeleporterImmunity(BinaryReader reader)
+        {
             var firstByte = reader.ReadByte();
             API.SplitSafe(firstByte, out var isGlobal, out var options);
             var duration = reader.ReadShortAsFloat();
             return new TeleporterImmunityData(isGlobal != 0, (ImmunityDurationMode) options, duration);
         }
 
-        public static void ReadTeleportData(BinaryReader reader, out Vector3 position, out TeleportOptions options) {
+        public static void ReadTeleportData(BinaryReader reader, out Vector3 position, out TeleportOptions options)
+        {
             position = reader.ReadVector();
             options = (TeleportOptions) reader.ReadByte();
         }

--- a/Scripts/slocExporter/TriggerActions/Readers/Ver5ActionDataReader.cs
+++ b/Scripts/slocExporter/TriggerActions/Readers/Ver5ActionDataReader.cs
@@ -1,0 +1,67 @@
+﻿using System.IO;
+using slocExporter.TriggerActions.Data;
+using slocExporter.TriggerActions.Enums;
+using UnityEngine;
+
+namespace slocExporter.TriggerActions.Readers
+{
+
+    public sealed class Ver5ActionDataReader : ITriggerActionDataReader
+    {
+
+        public BaseTriggerActionData Read(BinaryReader reader)
+        {
+            ActionManager.ReadTypes(reader, out var actionType, out var targetType, out var eventType);
+            BaseTriggerActionData data = actionType switch
+            {
+                TriggerActionType.TeleportToPosition => ReadTpToPos(reader),
+                TriggerActionType.MoveRelativeToSelf => ReadMoveRelative(reader),
+                TriggerActionType.TeleportToRoom => ReadTpToRoom(reader),
+                TriggerActionType.KillPlayer => Ver4ActionDataReader.ReadKillPlayer(reader),
+                TriggerActionType.TeleportToSpawnedObject => ReadTpToSpawnedObject(reader),
+                TriggerActionType.TeleporterImmunity => Ver4ActionDataReader.ReadTeleporterImmunity(reader),
+                _ => null
+            };
+            if (data is null)
+                return null;
+            data.SelectedTargets = targetType;
+            data.SelectedEvents = eventType;
+            return data;
+        }
+
+        public static TeleportToPositionData ReadTpToPos(BinaryReader reader)
+        {
+            ReadTeleportData(reader, out var position, out var options, out var rotation);
+            return new TeleportToPositionData(position) {Options = options, RotationY = rotation};
+        }
+
+        public static MoveRelativeToSelfData ReadMoveRelative(BinaryReader reader)
+        {
+            ReadTeleportData(reader, out var position, out var options, out var rotation);
+            return new MoveRelativeToSelfData(position) {Options = options, RotationY = rotation};
+        }
+
+        public static TeleportToRoomData ReadTpToRoom(BinaryReader reader)
+        {
+            ReadTeleportData(reader, out var position, out var options, out var rotation);
+            var name = reader.ReadString();
+            return new TeleportToRoomData(name, position) {Options = options, RotationY = rotation};
+        }
+
+        public static SerializableTeleportToSpawnedObjectData ReadTpToSpawnedObject(BinaryReader reader)
+        {
+            ReadTeleportData(reader, out var offset, out var options, out var rotation);
+            var virtualInstanceId = reader.ReadInt32();
+            return new SerializableTeleportToSpawnedObjectData(virtualInstanceId, offset, options, rotation);
+        }
+
+        public static void ReadTeleportData(BinaryReader reader, out Vector3 position, out TeleportOptions options, out float rotation)
+        {
+            position = reader.ReadVector();
+            options = (TeleportOptions) reader.ReadByte();
+            rotation = reader.ReadSingle();
+        }
+
+    }
+
+}

--- a/Scripts/slocExporter/TriggerActions/TriggerAction.cs
+++ b/Scripts/slocExporter/TriggerActions/TriggerAction.cs
@@ -3,9 +3,11 @@ using slocExporter.TriggerActions.Data;
 using slocExporter.TriggerActions.Enums;
 using UnityEngine;
 
-namespace slocExporter.TriggerActions {
+namespace slocExporter.TriggerActions
+{
 
-    public sealed class TriggerAction : MonoBehaviour {
+    public sealed class TriggerAction : MonoBehaviour
+    {
 
         public static TriggerActionGizmosDrawer CurrentGizmosDrawer = null;
 
@@ -46,7 +48,8 @@ namespace slocExporter.TriggerActions {
 
         #endregion
 
-        public BaseTriggerActionData SelectedData => type switch {
+        public BaseTriggerActionData SelectedData => type switch
+        {
             TriggerActionType.TeleportToPosition => tpToPos,
             TriggerActionType.TeleportToRoom => tpToRoom,
             TriggerActionType.TeleportToSpawnedObject => tpToSpawnedObject,
@@ -56,8 +59,10 @@ namespace slocExporter.TriggerActions {
             _ => null
         };
 
-        public void SetData(BaseTriggerActionData data) {
-            switch (type = data.ActionType) {
+        public void SetData(BaseTriggerActionData data)
+        {
+            switch (type = data.ActionType)
+            {
                 case TriggerActionType.TeleportToPosition:
                     tpToPos = data as TeleportToPositionData;
                     break;

--- a/Scripts/slocExporter/slocAttributes.cs
+++ b/Scripts/slocExporter/slocAttributes.cs
@@ -1,9 +1,11 @@
 ﻿using System;
 
-namespace slocExporter {
+namespace slocExporter
+{
 
     [Flags]
-    public enum slocAttributes : byte {
+    public enum slocAttributes : byte
+    {
 
         None = 0,
         LossyColors = 1,

--- a/Scripts/slocImporter.cs
+++ b/Scripts/slocImporter.cs
@@ -4,9 +4,11 @@ using slocExporter;
 using UnityEditor;
 using UnityEngine;
 
-public static class slocImporter {
+public static class slocImporter
+{
 
-    public static bool Init(string filePath, bool useExistingMaterials, bool colorsFolderOnly) {
+    public static bool Init(string filePath, bool useExistingMaterials, bool colorsFolderOnly)
+    {
         if (_inProgress)
             return false;
         _filePath = filePath;
@@ -23,31 +25,40 @@ public static class slocImporter {
 
     private static bool _inProgress;
 
-    public static void TryImport(ProgressUpdater updateProgress = null) {
-        if (_inProgress) {
+    public static void TryImport(ProgressUpdater updateProgress = null)
+    {
+        if (_inProgress)
+        {
             EditorUtility.DisplayDialog("slocImporter", "Import is already in progress", "OK");
             return;
         }
 
-        if (string.IsNullOrEmpty(_filePath)) {
+        if (string.IsNullOrEmpty(_filePath))
+        {
             EditorUtility.DisplayDialog("slocImporter", "You must specify a file to import!", "OK");
             return;
         }
 
         _inProgress = true;
 
-        try {
+        try
+        {
             DoImport(out var importedCount, out var objectName, updateProgress);
             EditorUtility.DisplayDialog("Import complete", $"Imported {importedCount} GameObject(s) as {objectName}", "OK");
-        } catch (Exception e) {
+        }
+        catch (Exception e)
+        {
             Debug.LogError(e);
             EditorUtility.DisplayDialog("slocImporter", "Import failed. See the debug log for details.", "OK");
-        } finally {
+        }
+        finally
+        {
             _inProgress = false;
         }
     }
 
-    private static void DoImport(out int importedCount, out string objectName, ProgressUpdater updateProgress = null) {
+    private static void DoImport(out int importedCount, out string objectName, ProgressUpdater updateProgress = null)
+    {
         EnsureColorsDirectoryExists();
         MaterialHandler.SkipForAll = false;
         MaterialHandler.CreateForAll = false;
@@ -61,7 +72,8 @@ public static class slocImporter {
         importedCount = spawned;
     }
 
-    private static void EnsureColorsDirectoryExists() {
+    private static void EnsureColorsDirectoryExists()
+    {
         if (!Directory.Exists("Assets/Colors"))
             Directory.CreateDirectory("Assets/Colors");
     }


### PR DESCRIPTION
# Changes (breaking):

- Renamed `SimplePositionRenderer::DrawCheckboxes` to `DrawCommonElements` and combined the default draw behavior method

# Additions:

- `StructureObject`
- `Ver5Reader`
- `StructureOverride`
- Teleport rotation
- `BaseTeleportData::ToWorldSpace(Transform, out Vector3, out float)`
- Added a constructor in `SerializableTeleportToSpawnedObjectData` with a `float` parameter for Y rotation
- `DeltaRotation` teleport option
- Added a link in `TeleportToRoomRenderer` to view room names
- Exporter and importer file paths are now kept between domain reloads

# Changes (non-breaking):

- Adjusted braces style
- `API.CurrentVersion` is now changed after updating sloc
- Fixed `ActionManager::Is(this TeleportOptions, TeleportOptions)` returning true when the options were `TeleportOptions.None`